### PR TITLE
fix(sarsa): preserve differential control credit across discounts

### DIFF
--- a/alberta_framework/core/average_reward.py
+++ b/alberta_framework/core/average_reward.py
@@ -213,7 +213,7 @@ def _preflight_actor_state(
 
 def _preflight_differential_sarsa_state(n_actions: int, feature_dim: int) -> None:
     parameters = n_actions * feature_dim
-    float32_scalars = 2 * parameters + 2 * n_actions + feature_dim + 2
+    float32_scalars = 2 * parameters + 2 * n_actions + feature_dim + 3
     # Two int32 leaves, a two-word RNG key, and a two-word lifetime counter.
     scalar_count = float32_scalars + 6
     _require_state_resources(
@@ -271,7 +271,7 @@ def _preflight_differential_gtd_state(feature_dim: int) -> None:
     )
 
 
-DIFFERENTIAL_SARSA_STATE_SCHEMA = "alberta.differential-sarsa-state.v2"
+DIFFERENTIAL_SARSA_STATE_SCHEMA = "alberta.differential-sarsa-state.v3"
 DIFFERENTIAL_SARSA_LIFETIME_COUNTER_NBYTES = 12
 DIFFERENTIAL_SARSA_LIFETIME_COUNTER_DELTA_NBYTES = 8
 
@@ -1975,7 +1975,11 @@ class DifferentialSARSAConfig:
 
 @chex.dataclass(frozen=True)
 class DifferentialSARSAState:
-    """State for linear differential SARSA."""
+    """State for linear differential SARSA.
+
+    ``previous_discount`` is the discount entering the cached decision, retained
+    from the preceding accepted transition for eligibility credit.
+    """
 
     q_weights: Float[Array, "n_actions feature_dim"]
     q_bias: Float[Array, " n_actions"]
@@ -1988,6 +1992,7 @@ class DifferentialSARSAState:
     rng_key: Array
     step_count: Int[Array, ""]
     step_words: UInt[Array, " 2"]
+    previous_discount: Float[Array, ""]
     birth_timestamp: float = 0.0
     uptime_s: float = 0.0
 
@@ -2032,7 +2037,10 @@ class DifferentialSARSAAgent:
     + gamma_{t+1} Q(S_{t+1}, A_{t+1}) - Q(S_t, A_t)`.
     The same scalar TD error updates the reward-rate estimate and all Q
     parameters through an action-indexed accumulating trace whose prior value
-    continues by `gamma_{t+1} lambda`. The compatibility default
+    continues by `gamma_t lambda`, using the preceding accepted transition's
+    discount. The current `gamma_{t+1}` controls bootstrapping and is saved for
+    the next update, so a zero discount cuts subsequent credit after applying
+    this transition's reward. The compatibility default
     `gamma_{t+1}=1` retains the original continuing-stream behavior.
     """
 
@@ -2099,6 +2107,7 @@ class DifferentialSARSAAgent:
             rng_key=key,
             step_count=jnp.array(0, dtype=jnp.int32),
             step_words=jnp.zeros((2,), dtype=jnp.uint32),
+            previous_discount=jnp.asarray(1.0, dtype=jnp.float32),
             birth_timestamp=time.time(),
             uptime_s=0.0,
         )
@@ -2126,6 +2135,7 @@ class DifferentialSARSAAgent:
             ("average_reward", state.average_reward, ()),
             ("last_observation", state.last_observation, (feature_dim,)),
             ("epsilon", state.epsilon, ()),
+            ("previous_discount", state.previous_discount, ()),
         )
         for name, value, shape in float_contracts:
             array = jnp.asarray(value)
@@ -2161,6 +2171,9 @@ class DifferentialSARSAAgent:
             & jnp.isfinite(state.epsilon)
             & (state.epsilon >= 0.0)
             & (state.epsilon <= 1.0)
+            & jnp.isfinite(state.previous_discount)
+            & (state.previous_discount >= 0.0)
+            & (state.previous_discount <= 1.0)
             & (state.last_action >= 0)
             & (state.last_action < self._config.n_actions)
             & jnp.isfinite(jnp.asarray(state.birth_timestamp, dtype=jnp.float32))
@@ -2377,7 +2390,9 @@ class DifferentialSARSAAgent:
         # With use_bias=False the bias gradient is zeroed, so q_bias stays at
         # its zero init and the Q-function is purely feature-driven.
         grad_bias = action_mask * jnp.float32(cfg.use_bias)
-        trace_continuation = discount_s * lamda
+        # Credit follows the discount entering the current decision; the
+        # outgoing discount only affects the next bootstrap and trace carry.
+        trace_continuation = state.previous_discount * lamda
         traces = trace_continuation * state.q_trace_weights + grad_weights
         bias_traces = trace_continuation * state.q_trace_bias + grad_bias
         new_step_count = _saturating_int32_increment(state.step_count)
@@ -2396,6 +2411,7 @@ class DifferentialSARSAAgent:
             q_bias=state.q_bias + alpha * td_error * bias_traces,
             q_trace_weights=traces,
             q_trace_bias=bias_traces,
+            previous_discount=discount_s,
             average_reward=new_average_reward,
             last_observation=next_observation_f,
             last_action=selected_next_action,
@@ -2536,8 +2552,16 @@ def measure_differential_sarsa_state_nbytes(state: DifferentialSARSAState) -> in
 
 def migrate_legacy_differential_sarsa_state(
     legacy_state: Any,
+    *,
+    previous_discount: float | None = None,
 ) -> DifferentialSARSAState:
-    """Migrate a pre-v2 state only when its int32 clock is unambiguous."""
+    """Migrate an exact v1/v2 payload with unambiguous clock and trace carry.
+
+    Active legacy traces require the preceding accepted discount from the
+    caller's transition record; it cannot be recovered from the old state.
+    Zero traces need no history and use a neutral discount of one. Migration
+    does not repair weights learned with the old discount indexing.
+    """
 
     if isinstance(legacy_state, Mapping):
         fields = dict(legacy_state)
@@ -2552,8 +2576,11 @@ def migrate_legacy_differential_sarsa_state(
         field.name
         for field in dataclasses.fields(DifferentialSARSAState)  # type: ignore[arg-type]
     }
-    legacy_names = current_names - {"step_words"}
+    legacy_names = current_names - {"previous_discount"}
     supplied_names = set(fields)
+    has_step_words = "step_words" in supplied_names
+    if not has_step_words:
+        legacy_names = legacy_names - {"step_words"}
     if supplied_names != legacy_names:
         missing = sorted(legacy_names - supplied_names)
         extra = sorted(supplied_names - legacy_names)
@@ -2567,7 +2594,23 @@ def migrate_legacy_differential_sarsa_state(
     step = int(step_count)
     if step < 0:
         raise ValueError("negative legacy differential SARSA step_count indicates wrap")
-    if step >= _INT32_MAX:
+    if not has_step_words and step >= _INT32_MAX:
         raise ValueError("saturated legacy differential SARSA step_count is ambiguous")
-    fields["step_words"] = jnp.asarray((0, step), dtype=jnp.uint32)
+    if has_step_words:
+        _checked_lifetime_words_increment(fields["step_words"])
+        if not bool(_lifetime_counter_valid(fields["step_words"], step_count)):
+            raise ValueError("legacy differential SARSA exact counter is inconsistent")
+    else:
+        fields["step_words"] = jnp.asarray((0, step), dtype=jnp.uint32)
+    if previous_discount is None:
+        if any(
+            not bool(jnp.all(jnp.asarray(fields[name]) == 0.0))
+            for name in ("q_trace_weights", "q_trace_bias")
+        ):
+            raise ValueError("active legacy traces require an explicit previous_discount")
+        previous_discount = 1.0
+    fields["previous_discount"] = jnp.asarray(
+        validated_float32_scalar("previous_discount", previous_discount, lower=0.0, upper=1.0),
+        dtype=jnp.float32,
+    )
     return DifferentialSARSAState(**fields)

--- a/alberta_framework/reference_life_controls.py
+++ b/alberta_framework/reference_life_controls.py
@@ -1799,6 +1799,7 @@ class DifferentialSARSAReferenceAdapter(_BaseReferenceControlAdapter):
             ("average_reward", learner.average_reward, ()),
             ("last_observation", learner.last_observation, (self.config.observation_dim,)),
             ("epsilon", learner.epsilon, ()),
+            ("previous_discount", learner.previous_discount, ()),
         )
         for name, value, shape in expected_float_shapes:
             array = np.asarray(value)
@@ -1838,6 +1839,8 @@ class DifferentialSARSAReferenceAdapter(_BaseReferenceControlAdapter):
         epsilon = float(learner.epsilon)
         if not 0.0 <= epsilon <= 1.0:
             raise DecisionOwnershipError("differential-SARSA epsilon is invalid")
+        if not 0.0 <= float(learner.previous_discount) <= 1.0:
+            raise DecisionOwnershipError("differential-SARSA previous_discount is invalid")
 
     def _advance_payload(
         self,

--- a/tests/test_differential_sarsa_delayed_credit.py
+++ b/tests/test_differential_sarsa_delayed_credit.py
@@ -1,0 +1,173 @@
+"""Delayed-reward credit must follow discounts between rewarded decisions."""
+
+from __future__ import annotations
+
+import dataclasses
+import pickle
+
+import chex
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.average_reward import (
+    DifferentialSARSAAgent,
+    DifferentialSARSAConfig,
+    measure_differential_sarsa_state_nbytes,
+    migrate_legacy_differential_sarsa_state,
+    run_differential_sarsa_from_arrays,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _agent(*, use_bias: bool = False) -> DifferentialSARSAAgent:
+    return DifferentialSARSAAgent(
+        DifferentialSARSAConfig(
+            n_actions=2,
+            q_step_size=0.1,
+            average_reward_step_size=0.0,
+            trace_decay=0.8,
+            epsilon_start=0.0,
+            use_bias=use_bias,
+        )
+    )
+
+
+@pytest.mark.parametrize("incoming", [0.0, 0.25, 1.0])
+@pytest.mark.parametrize("outgoing", [0.0, 0.1, 1.0])
+@pytest.mark.parametrize("use_bias", [False, True])
+def test_delayed_reward_uses_the_discount_entering_the_rewarded_decision(
+    incoming: float, outgoing: float, use_bias: bool
+) -> None:
+    """Zero initialized public transitions give an independent analytic update."""
+    agent = _agent(use_bias=use_bias)
+    observations = jnp.eye(3, dtype=jnp.float32)
+    state, _ = agent.start_with_action(
+        agent.init(3, jr.key(250, impl="threefry2x32")), observations[0], jnp.int32(0)
+    )
+    first = agent.update(
+        state, jnp.float32(0), observations[1], jnp.int32(1), discount=jnp.float32(incoming)
+    )
+    second = agent.update(
+        first.state,
+        jnp.float32(1),
+        observations[2],
+        jnp.int32(0),
+        discount=jnp.float32(outgoing),
+    )
+    assert bool(first.update_applied) and bool(second.update_applied)
+    assert float(first.td_error) == 0.0
+    assert float(second.td_error) == 1.0
+    expected = np.zeros((2, 3), dtype=np.float32)
+    expected[0, 0] = 0.1 * incoming * 0.8
+    expected[1, 1] = 0.1
+    np.testing.assert_allclose(second.state.q_weights, expected, atol=1e-7, rtol=1e-6)
+    np.testing.assert_allclose(
+        second.state.q_bias,
+        np.array([0.1 * incoming * 0.8, 0.1]) * use_bias,
+        atol=1e-7,
+        rtol=1e-6,
+    )
+
+
+def test_zero_discount_cuts_credit_to_the_previous_stream() -> None:
+    agent = _agent()
+    observations = jnp.eye(3, dtype=jnp.float32)
+    state, _ = agent.start_with_action(
+        agent.init(3, jr.key(251, impl="threefry2x32")), observations[0], jnp.int32(0)
+    )
+    first = agent.update(state, jnp.float32(0), observations[1], jnp.int32(1), discount=1.0)
+    boundary = agent.update(
+        first.state, jnp.float32(1), observations[2], jnp.int32(0), discount=0.0
+    )
+    following = agent.update(
+        boundary.state, jnp.float32(1), jnp.zeros(3), jnp.int32(1), discount=1.0
+    )
+    assert bool(following.update_applied)
+    chex.assert_trees_all_equal(following.state.q_weights[:, :2], boundary.state.q_weights[:, :2])
+    np.testing.assert_allclose(following.state.q_weights[0, 2], 0.1)
+
+
+def test_rejected_transition_and_pickle_resume_preserve_pending_credit() -> None:
+    agent = _agent()
+    observations = jnp.eye(3, dtype=jnp.float32)
+    state, _ = agent.start_with_action(
+        agent.init(3, jr.key(252, impl="threefry2x32")), observations[0], jnp.int32(0)
+    )
+    first = agent.update(state, jnp.float32(0), observations[1], jnp.int32(1), discount=0.25)
+    rejected = agent.update(
+        first.state, jnp.float32(jnp.nan), observations[2], jnp.int32(0), discount=0.0
+    )
+    assert not bool(rejected.update_applied)
+    chex.assert_trees_all_equal(rejected.state, first.state)
+    restored = pickle.loads(pickle.dumps(rejected.state))
+    direct = agent.update(first.state, jnp.float32(1), observations[2], jnp.int32(0), discount=0.0)
+    resumed = agent.update(restored, jnp.float32(1), observations[2], jnp.int32(0), discount=0.0)
+    chex.assert_trees_all_equal(direct, resumed)
+    np.testing.assert_allclose(resumed.state.q_weights[0, 0], 0.02)
+
+
+def test_array_runner_keeps_discount_history_and_boundary_credit() -> None:
+    agent = DifferentialSARSAAgent(dataclasses.replace(_agent().config, n_actions=1))
+    observations = jnp.eye(3, dtype=jnp.float32)
+    state, _ = agent.start(agent.init(3, jr.key(253, impl="threefry2x32")), observations[0])
+    result = run_differential_sarsa_from_arrays(
+        agent,
+        state,
+        jnp.array([0.0, 1.0, 1.0], dtype=jnp.float32),
+        jnp.stack([observations[1], observations[2], jnp.zeros(3)]),
+        discounts=jnp.array([0.25, 0.0, 1.0], dtype=jnp.float32),
+    )
+    assert bool(jnp.all(result.updates_applied))
+    np.testing.assert_allclose(result.state.q_weights, [[0.02, 0.1, 0.1]], rtol=1e-6)
+
+
+@pytest.mark.parametrize("discount", [-0.1, 1.1, float("nan"), float("inf")])
+def test_invalid_saved_discount_rejects_the_whole_update(discount: float) -> None:
+    agent = _agent()
+    state, _ = agent.start(agent.init(1, jr.key(254, impl="threefry2x32")), jnp.ones(1))
+    # Convert the pre-existing host telemetry to the compiled state dtype first.
+    state = agent.update(state, jnp.float32(0), jnp.ones(1)).state
+    poisoned = state.replace(previous_discount=jnp.float32(discount))
+    result = jax.jit(agent.update)(poisoned, jnp.float32(1), jnp.ones(1), discount=0.0)
+    assert not bool(result.state_valid)
+    assert not bool(result.update_applied)
+    for before, after in zip(jax.tree.leaves(poisoned), jax.tree.leaves(result.state), strict=True):
+        if jax.dtypes.issubdtype(before.dtype, jax.dtypes.prng_key):
+            before, after = jr.key_data(before), jr.key_data(after)
+        np.testing.assert_array_equal(before, after)
+
+
+@pytest.mark.parametrize("has_exact_clock", [False, True])
+def test_legacy_migration_requires_history_for_active_traces(has_exact_clock: bool) -> None:
+    agent = _agent()
+    state, _ = agent.start(agent.init(1, jr.key(255, impl="threefry2x32")), jnp.ones(1))
+    state = agent.update(state, jnp.float32(0), jnp.ones(1), discount=0.25).state
+    omitted = {"previous_discount"} | (set() if has_exact_clock else {"step_words"})
+    legacy = {
+        field.name: getattr(state, field.name)
+        for field in dataclasses.fields(state)
+        if field.name not in omitted
+    }
+    with pytest.raises(ValueError, match="explicit previous_discount"):
+        migrate_legacy_differential_sarsa_state(legacy)
+    migrated = migrate_legacy_differential_sarsa_state(legacy, previous_discount=0.25)
+    chex.assert_trees_all_equal(state, migrated)
+    with pytest.raises(ValueError, match="previous_discount"):
+        migrate_legacy_differential_sarsa_state(legacy, previous_discount=1.1)
+    with pytest.raises(ValueError, match="state schema"):
+        DifferentialSARSAAgent.from_config(
+            {**agent.to_config(), "state_schema": "alberta.differential-sarsa-state.v2"}
+        )
+
+
+def test_discount_cursor_adds_one_accounted_float32_scalar() -> None:
+    state = _agent().init(3, jr.key(256, impl="threefry2x32"))
+    assert state.previous_discount.shape == ()
+    assert state.previous_discount.dtype == jnp.float32
+    # Two Q/trace matrices, two bias/trace vectors, observation, reward rate,
+    # epsilon, the discount, two int32 scalars and four uint32 key/clock words.
+    assert measure_differential_sarsa_state_nbytes(state) == 4 * (2 * 2 * 3 + 2 * 2 + 3 + 3 + 6)

--- a/tests/test_differential_sarsa_discounts.py
+++ b/tests/test_differential_sarsa_discounts.py
@@ -45,7 +45,7 @@ def test_differential_sarsa_discount_hand_calculation(
     expected_weight_traces: list[list[float]],
     expected_bias_traces: list[float],
 ) -> None:
-    """Discount scales both the next-action bootstrap and old trace."""
+    """Equal incoming/outgoing discounts retain the constant-discount formula."""
     agent = DifferentialSARSAAgent(
         DifferentialSARSAConfig(
             n_actions=2,
@@ -69,6 +69,7 @@ def test_differential_sarsa_discount_hand_calculation(
         average_reward=jnp.array(0.25, dtype=jnp.float32),
         last_observation=jnp.array([1.0, 2.0], dtype=jnp.float32),
         last_action=jnp.array(0, dtype=jnp.int32),
+        previous_discount=jnp.array(discount, dtype=jnp.float32),
     )
 
     result = agent.update(

--- a/tests/test_differential_sarsa_discounts.py
+++ b/tests/test_differential_sarsa_discounts.py
@@ -94,6 +94,47 @@ def test_differential_sarsa_discount_hand_calculation(
     )
 
 
+def test_differential_sarsa_splits_incoming_trace_and_outgoing_bootstrap_discounts() -> None:
+    """The trace cursor and next-value bootstrap use opposite discount sides."""
+    agent = DifferentialSARSAAgent(
+        DifferentialSARSAConfig(
+            n_actions=1,
+            q_step_size=0.0,
+            average_reward_step_size=0.0,
+            trace_decay=0.8,
+            epsilon_start=0.0,
+            use_bias=False,
+        )
+    )
+    state = agent.init(2, jr.key(3)).replace(
+        q_weights=jnp.array([[0.5, 0.5]], dtype=jnp.float32),
+        q_trace_weights=jnp.array([[2.0, 0.0]], dtype=jnp.float32),
+        last_observation=jnp.array([1.0, 0.0], dtype=jnp.float32),
+        last_action=jnp.array(0, dtype=jnp.int32),
+        previous_discount=jnp.array(0.25, dtype=jnp.float32),
+    )
+
+    result = agent.update(
+        state,
+        jnp.array(1.0, dtype=jnp.float32),
+        jnp.array([0.0, 1.0], dtype=jnp.float32),
+        next_action=jnp.array(0, dtype=jnp.int32),
+        discount=jnp.array(0.7, dtype=jnp.float32),
+    )
+
+    # delta = reward + outgoing_gamma * Q(next) - Q(previous)
+    chex.assert_trees_all_close(result.td_error, jnp.array(0.85, dtype=jnp.float32))
+    # e = incoming_gamma * lambda * previous_e + grad Q(previous)
+    chex.assert_trees_all_close(
+        result.state.q_trace_weights,
+        jnp.array([[1.4, 0.0]], dtype=jnp.float32),
+    )
+    chex.assert_trees_all_equal(
+        result.state.previous_discount,
+        jnp.array(0.7, dtype=jnp.float32),
+    )
+
+
 def test_differential_sarsa_array_runner_uses_transition_discounts() -> None:
     """The array runner forwards each discount; omission retains gamma=1."""
     agent = DifferentialSARSAAgent(

--- a/tests/test_differential_sarsa_horizon.py
+++ b/tests/test_differential_sarsa_horizon.py
@@ -255,7 +255,7 @@ def test_schema_migration_and_counter_byte_accounting_are_strict() -> None:
     legacy = {
         field.name: getattr(state, field.name)
         for field in dataclasses.fields(state)  # type: ignore[arg-type]
-        if field.name != "step_words"
+        if field.name not in {"step_words", "previous_discount"}
     }
     legacy["step_count"] = jnp.asarray(19, dtype=jnp.int32)
     migrated = migrate_legacy_differential_sarsa_state(legacy)

--- a/tests/test_reference_life_controls.py
+++ b/tests/test_reference_life_controls.py
@@ -797,6 +797,21 @@ def test_learning_control_state_validation_requires_exact_persistent_dtypes() ->
     assert isinstance(differential_state, ReferenceLifeControlState)
     differential_learner = differential_state.agent_state
     assert isinstance(differential_learner, DifferentialSARSAState)
+    for bad_discount in (
+        jnp.asarray(0, dtype=jnp.int32),
+        jnp.asarray([1.0], dtype=jnp.float32),
+        jnp.asarray(-0.1, dtype=jnp.float32),
+        jnp.asarray(1.1, dtype=jnp.float32),
+    ):
+        with pytest.raises(DecisionOwnershipError, match="previous_discount"):
+            differential.validate_state(
+                dataclasses.replace(
+                    differential_state,
+                    agent_state=differential_learner.replace(  # type: ignore[attr-defined]
+                        previous_discount=bad_discount
+                    ),
+                )
+            )
     bad_differential_words = differential_learner.replace(  # type: ignore[attr-defined]
         step_words=jnp.asarray((0, 0), dtype=jnp.int32)
     )

--- a/tests/test_runtime_profile_json_nest.py
+++ b/tests/test_runtime_profile_json_nest.py
@@ -64,11 +64,9 @@ def test_origin_recursion_class_rejects_before_dumps(
         raise AssertionError("json.dumps ran before the runtime-profile nest gate")
 
     monkeypatch.setattr(json, "dumps", fail_dumps)
-    # Keep fixture allocation and teardown outside the validator's time budget.
-    profile = _nest(16_000)
     started = time.perf_counter()
     with pytest.raises(ValueError, match="nesting depth"):
-        validate_environment_runtime_profile(profile)
+        validate_environment_runtime_profile(_nest(16_000))
     assert time.perf_counter() - started < 0.25
 
 

--- a/tests/test_runtime_profile_json_nest.py
+++ b/tests/test_runtime_profile_json_nest.py
@@ -64,9 +64,11 @@ def test_origin_recursion_class_rejects_before_dumps(
         raise AssertionError("json.dumps ran before the runtime-profile nest gate")
 
     monkeypatch.setattr(json, "dumps", fail_dumps)
+    # Keep fixture allocation and teardown outside the validator's time budget.
+    profile = _nest(16_000)
     started = time.perf_counter()
     with pytest.raises(ValueError, match="nesting depth"):
-        validate_environment_runtime_profile(_nest(16_000))
+        validate_environment_runtime_profile(profile)
     assert time.perf_counter() - started < 0.25
 
 


### PR DESCRIPTION
Differential SARSA discards delayed reward credit when a transition ends with discount zero, and carries that decision's trace into the following stream. It currently decays eligibility with the outgoing discount used for bootstrapping. Retain the preceding accepted discount and use that for eligibility instead; rejected updates preserve it with the rest of the state.

For a public `init/start_with_action/update` reproduction with zero initial weights, observations `[1,0,0] -> [0,1,0] -> [0,0,1]`, actions `0 -> 1`, rewards `[0,1]`, discounts `[0.5,0]`, step size `0.1`, lambda `0.8`, no bias, and frozen reward-rate estimate, the first action must receive `0.1 * 0.5 * 0.8 = 0.04`. Main gives it zero. This fix gives it `0.04` and cuts eligibility before crediting a subsequent stream.

This uses the variable-discount trace recurrence `e_t = gamma_t * lambda * e_(t-1) + grad Q(S_t,A_t)`, while the bootstrap uses `gamma_(t+1)`. See [Sutton & Barto, January 2018 draft, §§12.8–12.9](https://eclass.uoa.gr/modules/document/file.php/DI437/bookdraft2018jan1.pdf). The differential reward-rate update is unchanged.

The new float32 discount costs four persistent bytes. Core state validation and the reference-life adapter enforce its scalar dtype and `[0,1]` range. The core state schema advances to v3; v1/v2 migration requires an explicit preceding discount if eligibility is active. It preserves exact v2 lifetime counters and retains the existing rejection of ambiguous v1 clocks. Older weights learned with the faulty recurrence cannot be repaired by migration.

Initial validation at `da4a2d6cb736c561a677924c8ba3acacca1cd02f`, against current main `f3d32c451ed1c1715e477ad56b782fc7ea89b206`, with locked Python 3.12.3 / JAX 0.11.0 / NumPy 2.5.1:

- Failure first: 15 new regressions fail on main; four controls pass.
- Across incoming discounts `{0,0.25,1}`, outgoing discounts `{0,0.1,1}`, and both bias settings, main matches 4/18 analytic updates; this head matches 18/18. Initialization uses Threefry key 250 and public methods only.
- Nine constant-discount replays use development seeds 257–259, discounts `{0,0.5,1}`, and 32 transitions each. Both sources accept all 288 updates. All 3,744 compared arrays match exactly, including Q parameters, traces, reward-rate estimates, action/RNG/counter state, and TD diagnostics. Host timestamps and the newly added discount field are excluded.
- 56 focused tests pass, including boundary isolation, rejected-update atomicity, pickle continuation, scan execution, legacy migration, exact lifetime counters, and external action ownership.
- At the first commit (`2d838141d89501dd31ab293004cf9f46e4d08072`), 148 average-reward/control tests pass. A separate overlapping scorecard/control/resource panel passes 106 tests, with one expected non-Linux-path skip on Linux. Library source bytes are unchanged by the subsequent timing-test correction.
- Ruff, formatting of the new test file, strict mypy over 224 source files, and `git diff --check` pass.

Focused reproduction:

```bash
OMP_NUM_THREADS=1 .venv/bin/python -m pytest \
  tests/test_differential_sarsa_delayed_credit.py \
  tests/test_differential_sarsa_discounts.py \
  tests/test_differential_sarsa_horizon.py \
  tests/test_differential_sarsa_external_action.py -q -o addopts= --tb=short
```

These are bounded correctness diagnostics, not benchmark performance or scientific evidence. The five registry claims retain their pre-existing invalid statuses and identical error lists. `average_reward.py` is registered by the IA claim; both edited library files affect reference-life provenance. No pinned artifact was changed, no frozen campaign resumed, and no scorecard result is claimed.

[Required CI passed all 55 jobs at the prior measured head](https://github.com/SlopDotCash/asi/actions/runs/34293064711). The formerly failing Python 3.12 shard 18 passes 689 tests; the matching Python 3.13 shard also passes.

The attached public proof bundle is `differential-sarsa-incoming-discount.evidence.zip` (243,031 bytes; SHA-256 `097c7ab775ffb4d4c95f296510f10ca18d5217ed7af9b3d5a38eb7cc57001631`). It contains the standalone reproductions, baseline/candidate records and arrays, timing observations, test logs, and per-file digests.

Ready for review: the minimized private trace was permanently uploaded, the signed receipt below was finalized, and both public evidence attachments were verified after GitHub publication. No independent acceptance is claimed.

## Current-head review repair (`61844a5cafd5e32c41d370e848d1060bd2d9577e`)

The unrelated runtime-profile timing hunk has been removed from the net diff. A new nonzero-value
regression now pins both halves of the variable-discount recurrence in one public update: with
incoming discount 0.25 and outgoing discount 0.7, the TD error is
`1 + 0.7 * 0.5 - 0.5 = 0.85`, while the carried trace is
`0.25 * 0.8 * 2 + 1 = 1.4`. It also verifies that the outgoing 0.7 becomes the next stored
discount. The reference adapter was inspected and returns `result.state` wholesale, so the cursor
is not rebuilt or lost at that boundary.

The new regression fails against current `main` because the old state has no discount cursor.
At this head, the focused SARSA/reference-control panel passes 90 tests; Ruff passes on the touched
lane, strict mypy passes across 224 source files, formatting and `git diff --check` pass. These are
bounded correctness diagnostics, not benchmark performance or scientific evidence.

<!-- evidence-head:61844a5cafd5e32c41d370e848d1060bd2d9577e -->
<!-- evidence-row:logs -->
- [x] logs: [`differential-sarsa-incoming-discount.logs.txt`](https://github.com/user-attachments/files/32064074/differential-sarsa-incoming-discount.logs.txt), SHA-256 `ad4edd21658323d797b462ce6c681d670df6d46cf92046aa31c03f8df0d7989e`.
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: [`differential-sarsa-incoming-discount.evidence.zip`](https://github.com/user-attachments/files/32064078/differential-sarsa-incoming-discount.evidence.zip), SHA-256 `097c7ab775ffb4d4c95f296510f10ca18d5217ed7af9b3d5a38eb7cc57001631`.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-6
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next25]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-6","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M21NCEMQ9XXC0FVYZHM6B1QG","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-08T23:24:21.528Z","completed_at":"2026-09-09T14:02:26.135Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-08T23:24:21.674Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"bb942328ab15cda4b21a6152b73b630d01d1d1c83cb69499bce6361633c267b3","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"76ab00ec-3c91-4301-808c-547f609cb7b4","object_id":"sha256:bb942328ab15cda4b21a6152b73b630d01d1d1c83cb69499bce6361633c267b3","sha256":"bb942328ab15cda4b21a6152b73b630d01d1d1c83cb69499bce6361633c267b3"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"ebkLCELzpriVWG-NU66jOMyzyUi2soIM9oFS89LtmohN-7EZ-sCLG79wmnsxkHDELBxpOgPxBDPGbED59PTIBA"}} -->
