### PR TITLE
fix(etd): use incoming discount for emphatic traces

### DIFF
--- a/alberta_framework/core/off_policy_td.py
+++ b/alberta_framework/core/off_policy_td.py
@@ -284,6 +284,9 @@ class ETDState:
         bias_eligibility_trace: Emphatic eligibility trace for the bias
         follow_on_trace: Scalar follow-on trace ``F_t``
         emphasis: Scalar emphasis ``M_t`` from the latest update
+        previous_gamma: Discount of the preceding accepted transition, used
+            by both the follow-on and eligibility recurrences. Legacy state
+            without this history is rejected; it must be supplied explicitly.
         previous_rho: Importance ratio from the prior update call, carried
             forward so the *next* call can advance ``F_t`` on ``rho_{t-1}``
             (Sutton, Mahmood & White 2016, eq. 20) rather than on the ratio
@@ -299,6 +302,7 @@ class ETDState:
     bias_eligibility_trace: Float[Array, ""]
     follow_on_trace: Float[Array, ""]
     emphasis: Float[Array, ""]
+    previous_gamma: Float[Array, ""] = None  # type: ignore[assignment]
     previous_rho: Float[Array, ""] = None  # type: ignore[assignment]
     step_count: Int[Array, ""] = None  # type: ignore[assignment]
     birth_timestamp: float = 0.0
@@ -404,8 +408,14 @@ def _etd_state_contract(state: object) -> tuple[ETDState, int]:
     _array_metadata("state.weights", checked.weights, (feature_dim,))
     _array_metadata("state.bias", checked.bias, ())
     _array_metadata("state.eligibility_traces", checked.eligibility_traces, (feature_dim,))
-    for name in ("bias_eligibility_trace", "follow_on_trace", "emphasis", "previous_rho"):
-        _array_metadata(f"state.{name}", getattr(checked, name), ())
+    for name in (
+        "bias_eligibility_trace",
+        "follow_on_trace",
+        "emphasis",
+        "previous_gamma",
+        "previous_rho",
+    ):
+        _array_metadata(f"state.{name}", getattr(checked, name, None), ())
     try:
         step_shape = tuple(checked.step_count.shape)
         step_dtype = np.dtype(checked.step_count.dtype)
@@ -690,9 +700,10 @@ class ETDLinearLearner:
     ``e_t = rho_t * (gamma_t * lambda * e_{t-1} + M_t * phi_t)``
     ``w_{t+1} = w_t + alpha * delta_t * e_t``
 
-    The single-step API advances the follow-on trace with the current
-    transition's ratio and discount. With ``rho=1``, ``gamma=0``, and
-    ``lambda=0``, this reduces to the standard LMS/TD(0) terminating update.
+    The single-step API receives the outgoing discount ``gamma_{t+1}`` for
+    bootstrapping and retains it for the next call's two trace recurrences.
+    With constant ``rho=1``, ``gamma=0``, and ``lambda=0``, this reduces to
+    the standard LMS/TD(0) terminating update.
 
     Attributes:
         step_size: Learning rate alpha
@@ -728,7 +739,7 @@ class ETDLinearLearner:
     def init(self, feature_dim: int) -> ETDState:
         """Initialize learner state with zero weights and zero traces."""
         feature_dim = _require_feature_dim(
-            feature_dim, vectors=2, fixed_scalars=6, update_vectors=9
+            feature_dim, vectors=2, fixed_scalars=7, update_vectors=9, update_scalars=17
         )
         return ETDState(  # type: ignore[call-arg]
             weights=jnp.zeros(feature_dim, dtype=jnp.float32),
@@ -737,6 +748,7 @@ class ETDLinearLearner:
             bias_eligibility_trace=jnp.array(0.0, dtype=jnp.float32),
             follow_on_trace=jnp.array(0.0, dtype=jnp.float32),
             emphasis=jnp.array(0.0, dtype=jnp.float32),
+            previous_gamma=jnp.array(1.0, dtype=jnp.float32),
             previous_rho=jnp.array(1.0, dtype=jnp.float32),
             step_count=jnp.array(0, dtype=jnp.int32),
             birth_timestamp=time.time(),
@@ -770,7 +782,7 @@ class ETDLinearLearner:
             observation: Current feature vector phi(s_t)
             reward: Reward R_{t+1}
             next_observation: Next feature vector phi(s_{t+1})
-            gamma: State-dependent discount gamma (0 at terminal)
+            gamma: Outgoing discount gamma_{t+1} (0 at terminal)
             rho: Importance-sampling ratio pi(a_t|s_t) / b(a_t|s_t).
             interest: State interest i_t. Defaults to 1.0.
 
@@ -822,17 +834,18 @@ class ETDLinearLearner:
 
         # F_t = rho_{t-1} * gamma_t * F_{t-1} + i_t (Sutton, Mahmood & White
         # 2016, eq. 20): the follow-on trace advances on the PRIOR call's
-        # ratio (state.previous_rho), not rho_s -- only e_t below uses rho_s.
+        # ratio and discount, not rho_s or gamma_s. Only e_t uses rho_s;
+        # gamma_s belongs to the TD bootstrap and the next call's history.
         follow_on = (
             _skip_zero_scale(
-                gamma_s,
+                state.previous_gamma,
                 _skip_zero_scale(state.previous_rho, state.follow_on_trace),
             )
             + interest_s
         )
         emphasis = _skip_zero_scale(lam, interest_s) + _skip_zero_scale(1.0 - lam, follow_on)
 
-        trace_decay = gamma_s * lam
+        trace_decay = state.previous_gamma * lam
         eligibility_core = (
             _skip_zero_scale(trace_decay, state.eligibility_traces) + emphasis * observation
         )
@@ -847,6 +860,7 @@ class ETDLinearLearner:
             bias_eligibility_trace=new_e_b,
             follow_on_trace=follow_on,
             emphasis=emphasis,
+            previous_gamma=gamma_s,
             previous_rho=rho_s,
             step_count=jnp.minimum(state.step_count, _INT32_MAX - 1) + 1,
             birth_timestamp=state.birth_timestamp,
@@ -858,14 +872,16 @@ class ETDLinearLearner:
             & ((gamma_s == 0.0) | jnp.all(jnp.isfinite(next_observation)))
             & (gamma_s >= 0.0)
             & (gamma_s <= 1.0)
+            & (state.previous_gamma >= 0.0)
+            & (state.previous_gamma <= 1.0)
             & jnp.isfinite(rho_s)
             & jnp.isfinite(interest_s)
         )
         previous_checked = state.replace(  # type: ignore[attr-defined]
             eligibility_traces=_zero_if_unused(trace_decay, state.eligibility_traces),
             bias_eligibility_trace=_zero_if_unused(trace_decay, state.bias_eligibility_trace),
-            follow_on_trace=_zero_if_unused(gamma_s, state.follow_on_trace),
-            previous_rho=_zero_if_unused(gamma_s, state.previous_rho),
+            follow_on_trace=_zero_if_unused(state.previous_gamma, state.follow_on_trace),
+            previous_rho=_zero_if_unused(state.previous_gamma, state.previous_rho),
         )
         squared_td = td_error**2
         mean_e = jnp.mean(jnp.abs(proposed_state.eligibility_traces))

--- a/tests/test_baird.py
+++ b/tests/test_baird.py
@@ -283,6 +283,7 @@ class TestRhoZeroInvariance:
             weights=jnp.asarray(W_INIT),
             bias=jnp.float32(0.5),
             follow_on_trace=jnp.float32(3.0),
+            previous_gamma=jnp.float32(GAMMA),
             previous_rho=jnp.float32(RHO_SOLID),
         )
         result = learner.update(

--- a/tests/test_etd_discount_history.py
+++ b/tests/test_etd_discount_history.py
@@ -1,0 +1,138 @@
+"""Public ETD updates follow the incoming discount in JMLR 2016, eqs. 17–20."""
+
+from __future__ import annotations
+
+import pickle
+
+import chex
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.core.off_policy_td import ETDLinearLearner
+
+
+@pytest.mark.parametrize("trace_decay", [0.0, 0.4, 1.0])
+@pytest.mark.parametrize("incoming", [0.0, 0.5, 1.0])
+@pytest.mark.parametrize("outgoing", [0.0, 0.5, 1.0])
+def test_delayed_credit_and_emphasis_use_incoming_discount(
+    trace_decay: float, incoming: float, outgoing: float
+) -> None:
+    learner = ETDLinearLearner(step_size=0.1, trace_decay=trace_decay)
+    observations = jnp.eye(3, dtype=jnp.float32)
+    first = learner.update(learner.init(3), observations[0], 0.0, observations[1], incoming, 2.0)
+    second = learner.update(first.state, observations[1], 1.0, observations[2], outgoing, 0.5)
+    assert bool(first.update_applied) and bool(second.update_applied)
+
+    # First F and M are one, so e_0 = 2 * phi_0. No weights change until r_2.
+    follow_on = 1.0 + 2.0 * incoming
+    emphasis = trace_decay + (1.0 - trace_decay) * follow_on
+    traces = np.array([incoming * trace_decay, 0.5 * emphasis, 0.0], dtype=np.float32)
+    np.testing.assert_allclose(second.state.follow_on_trace, follow_on, rtol=1e-6)
+    np.testing.assert_allclose(second.state.emphasis, emphasis, rtol=1e-6)
+    np.testing.assert_allclose(second.state.eligibility_traces, traces, rtol=1e-6)
+    np.testing.assert_allclose(second.state.weights, 0.1 * traces, rtol=1e-6)
+    np.testing.assert_allclose(second.state.bias, 0.1 * traces.sum(), rtol=1e-6)
+
+
+def test_terminal_boundary_isolates_the_next_stream() -> None:
+    learner = ETDLinearLearner(step_size=0.1, trace_decay=0.4)
+    observations = jnp.eye(3, dtype=jnp.float32)
+    terminal = learner.update(learner.init(3), observations[0], 0.0, observations[1], 0.0, 3.0)
+    following = learner.update(
+        terminal.state, observations[1], 1.0, observations[2], 0.9, 1.0, interest=0.5
+    )
+    assert bool(terminal.update_applied) and bool(following.update_applied)
+    np.testing.assert_allclose(following.state.follow_on_trace, 0.5)
+    np.testing.assert_allclose(following.state.emphasis, 0.5)
+    np.testing.assert_allclose(following.state.eligibility_traces, [0.0, 0.5, 0.0])
+    np.testing.assert_allclose(following.state.weights, [0.0, 0.05, 0.0], rtol=1e-6)
+
+
+def test_rejection_does_not_advance_discount_or_ratio_history() -> None:
+    learner = ETDLinearLearner(step_size=0.1, trace_decay=0.4)
+    observations = jnp.eye(3, dtype=jnp.float32)
+    first = learner.update(learner.init(3), observations[0], 0.0, observations[1], 0.5, 2.0)
+    rejected = learner.update(
+        first.state, observations[1], jnp.float32(jnp.nan), observations[2], 0.0, 7.0
+    )
+    assert not bool(rejected.update_applied)
+    chex.assert_trees_all_equal(rejected.state, first.state)
+    continued = learner.update(rejected.state, observations[1], 1.0, observations[2], 0.0, 0.5)
+    direct = learner.update(first.state, observations[1], 1.0, observations[2], 0.0, 0.5)
+    chex.assert_trees_all_equal(continued, direct)
+
+
+@pytest.mark.parametrize("discount", [-0.1, 1.1, float("nan"), float("inf")])
+def test_invalid_saved_discount_rejects_even_when_traces_are_zero(discount: float) -> None:
+    learner = ETDLinearLearner(trace_decay=0.0)
+    state = learner.init(2).replace(previous_gamma=jnp.float32(discount))
+    result = learner.update(state, jnp.ones(2), 1.0, jnp.zeros(2), 0.0, 1.0)
+    assert not bool(result.update_applied)
+    for name, value in state.items():
+        np.testing.assert_array_equal(result.state[name], value)
+
+
+@pytest.mark.parametrize("history", [None, np.ones(1, dtype=np.float32), np.float32(0.5)])
+def test_missing_or_noncanonical_saved_discount_is_not_inferred(history: object) -> None:
+    learner = ETDLinearLearner()
+    state = learner.init(2).replace(previous_gamma=history)
+    with pytest.raises(ValueError, match="state.previous_gamma"):
+        learner.update(state, jnp.ones(2), 1.0, jnp.zeros(2), 0.0, 1.0)
+
+
+def test_terminal_bootstrap_does_not_discard_required_invalid_history() -> None:
+    learner = ETDLinearLearner(trace_decay=0.4)
+    state = learner.init(2).replace(follow_on_trace=jnp.float32(jnp.inf))
+    result = learner.update(state, jnp.ones(2), 1.0, jnp.zeros(2), 0.0, 1.0)
+    assert not bool(result.update_applied)
+    chex.assert_trees_all_equal(result.state, state)
+
+
+def test_pickle_continuation_preserves_incoming_discount() -> None:
+    learner = ETDLinearLearner(step_size=0.1, trace_decay=0.8)
+    observations = jnp.eye(3, dtype=jnp.float32)
+    first = learner.update(learner.init(3), observations[0], 0.0, observations[1], 0.5, 2.0)
+    restored = pickle.loads(pickle.dumps(first.state))
+    resumed = learner.update(restored, observations[1], 1.0, observations[2], 0.0, 0.5)
+    direct = learner.update(first.state, observations[1], 1.0, observations[2], 0.0, 0.5)
+    chex.assert_trees_all_equal(resumed, direct)
+    np.testing.assert_allclose(resumed.state.weights, [0.04, 0.06, 0.0], rtol=1e-6)
+
+
+def test_public_update_scan_retains_history_across_a_boundary() -> None:
+    learner = ETDLinearLearner(step_size=0.1, trace_decay=0.8)
+    observations = jnp.eye(3, dtype=jnp.float32)
+    inputs = (
+        observations,
+        jnp.roll(observations, -1, axis=0),
+        jnp.array([0.0, 1.0, 0.5], dtype=jnp.float32),
+        jnp.array([0.5, 0.0, 0.75], dtype=jnp.float32),
+        jnp.array([2.0, 0.5, 1.0], dtype=jnp.float32),
+    )
+    initial = learner.init(3)
+
+    def step(state, transition):
+        observation, next_observation, reward, gamma, rho = transition
+        result = learner.update(state, observation, reward, next_observation, gamma, rho)
+        return result.state, result.update_applied
+
+    scanned, applied = jax.lax.scan(step, initial, inputs)
+    sequential = initial
+    for transition in zip(*inputs, strict=True):
+        sequential, accepted = step(sequential, transition)
+        assert bool(accepted)
+    assert bool(jnp.all(applied))
+    chex.assert_trees_all_equal(scanned, sequential)
+    np.testing.assert_array_equal(scanned.eligibility_traces, [0.0, 0.0, 1.0])
+    np.testing.assert_array_equal(scanned.follow_on_trace, 1.0)
+
+
+def test_numeric_state_accounts_for_the_saved_discount() -> None:
+    state = ETDLinearLearner().init(3)
+    payload = sum(value.nbytes for value in state.values() if isinstance(value, jax.Array))
+    assert state.previous_gamma.shape == ()
+    assert state.previous_gamma.dtype == jnp.float32
+    assert state.previous_gamma.nbytes == 4
+    assert payload == 4 * (2 * 3 + 7)

--- a/tests/test_off_policy_td.py
+++ b/tests/test_off_policy_td.py
@@ -417,15 +417,16 @@ class TestETDLambda:
         # F_t = rho_{t-1} * gamma_t * F_{t-1} + i_t (Sutton, Mahmood & White
         # 2016, eq. 20): F advances on the PRIOR step's rho, not the current
         # one. init()'s previous_rho=1.0 is irrelevant here since F_0=0.
-        # F_1 = 1.0 * 0.9 * 0 + 1 = 1
-        # F_2 = rho_1 * 0.8 * 1 + 1 = 2.0 * 0.8 * 1 + 1 = 2.6
-        # M_2 = lambda * i + (1 - lambda) * F_2 = 0.4 + 0.6 * 2.6 = 1.96
+        # F_1 = 1, since the initial follow-on trace is zero.
+        # The incoming discount on step 2 is the prior call's 0.9:
+        # F_2 = rho_1 * 0.9 * 1 + 1 = 2.8
+        # M_2 = lambda * i + (1 - lambda) * F_2 = 0.4 + 0.6 * 2.8 = 2.08
         chex.assert_trees_all_close(first.state.follow_on_trace, jnp.float32(1.0))
-        chex.assert_trees_all_close(second.state.follow_on_trace, jnp.float32(2.6))
-        chex.assert_trees_all_close(second.state.emphasis, jnp.float32(1.96))
+        chex.assert_trees_all_close(second.state.follow_on_trace, jnp.float32(2.8))
+        chex.assert_trees_all_close(second.state.emphasis, jnp.float32(2.08))
         chex.assert_trees_all_close(
             second.state.eligibility_traces,
-            jnp.array([0.32, 0.98], dtype=jnp.float32),
+            jnp.array([0.36, 1.04], dtype=jnp.float32),
             atol=1e-6,
         )
 
@@ -451,11 +452,11 @@ class TestETDLambda:
             )
             state = result.state
 
-        # F_1 = previous_rho(init=1.0) * 0.5 * F_0(=0) + 1 = 1.0
-        # F_2 = rho_1(=3.0) * 0.9 * F_1(=1.0) + 1 = 3.7
-        # F_3 = rho_2(=0.1) * 0.7 * F_2(=3.7) + 1 = 1.259
-        # (using rho_t instead of rho_{t-1} at each step gives F_3 = 4.052)
-        chex.assert_trees_all_close(state.follow_on_trace, jnp.float32(1.259), atol=1e-5)
+        # F_1 = 1.0 because the initial follow-on trace is zero.
+        # F_2 = rho_1(=3.0) * gamma_1(=0.5) * F_1(=1.0) + 1 = 2.5
+        # F_3 = rho_2(=0.1) * gamma_2(=0.9) * F_2(=2.5) + 1 = 1.225
+        # Using current rho with incoming gamma instead would give F_3 = 4.78.
+        chex.assert_trees_all_close(state.follow_on_trace, jnp.float32(1.225), atol=1e-5)
 
     def test_update_is_jit_compatible(self) -> None:
         learner = ETDLinearLearner(step_size=0.05, trace_decay=0.5)
@@ -1025,9 +1026,10 @@ class TestZeroGammaDoesNotMultiplyInfBootstrap:
         assert bool(jnp.isfinite(result.state.bias_eligibility_trace))
 
     def test_etd_does_not_multiply_inf_follow_on(self) -> None:
-        """gamma=0 drops leftover F; 0 * inf must not freeze the ETD step."""
+        """Incoming gamma=0 drops leftover F; 0 * inf must not freeze the step."""
         learner = ETDLinearLearner(step_size=0.1, trace_decay=0.4)
         state = learner.init(2).replace(  # type: ignore[attr-defined]
+            previous_gamma=jnp.asarray(0.0, dtype=jnp.float32),
             follow_on_trace=jnp.asarray(jnp.inf, dtype=jnp.float32),
             eligibility_traces=jnp.full(2, jnp.inf, dtype=jnp.float32),
             bias_eligibility_trace=jnp.asarray(jnp.inf, dtype=jnp.float32),


### PR DESCRIPTION
Emphatic TD uses the outgoing transition discount to decay both its follow-on and eligibility traces. A terminal reward therefore erases earlier credit before applying the update, and the following stream inherits stale emphasis. Carry the preceding accepted discount for both trace recurrences; retain the outgoing discount for the TD bootstrap.

A public two-transition reproduction starts with zero weights, observations `e0 -> e1 -> e2`, rewards `[0,1]`, discounts `[0.5,0]`, importance ratios `[2,0.5]`, interests `[1,1]`, step size `0.1`, and lambda `0.8`. The terminal update should have follow-on trace `2`, emphasis `1.2`, weights `[0.04,0.06,0]`, and bias `0.1`. Main instead produces follow-on `1`, emphasis `1`, weights `[0,0.05,0]`, and bias `0.05`. The corrected incoming-zero boundary also clears both traces before the next stream receives credit.

This restores the separate `gamma_t` trace and `gamma_(t+1)` bootstrap indices in [Sutton, Mahmood & White (2016), equations 17–20](https://jmlr.org/papers/volume17/14-488/14-488.pdf). The previous importance ratio still controls the follow-on trace, and the current ratio still controls eligibility.

The saved `previous_gamma` adds one float32 scalar: the four-feature numeric state grows from 56 to 60 bytes, excluding unchanged host metadata. Constructor resource bounds include it. Public state validation rejects missing or noncanonical history; updates reject an out-of-range or nonfinite saved discount and preserve the complete prior state on failure. Legacy state requires an explicit preceding discount from its transition history. This does not repair weights already learned with the faulty recurrence.

Validation at `dd8a5b6f40313d093250514ce09b46625e934165`, against main `f3d32c451ed1c1715e477ad56b782fc7ea89b206`, with locked Python 3.12.3 / JAX 0.11.0 / NumPy 2.5.1:

- Failure first: 19 failures and nine controls passing on main. The fixed 28-case regression passes.
- Analytic matrix: incoming and outgoing discounts each in `{0,0.5,1}`, lambdas in `{0,0.4,1}`. Main matches 9/27; candidate matches 27/27.
- Independent NumPy recurrence: development seeds `270,271,272`, three lambdas, 32 transitions each, with a repeating outgoing discount schedule `[0.5,0,0.9,1,0.25]`. Main matches 9/288 steps; candidate matches 288/288. Each seed improves from 3/96 to 96/96 matching steps. The predeclared numeric tolerance is `atol=2e-7, rtol=2e-6`.
- Constant-discount controls: the same three seeds and lambdas at discounts `{0,0.5,0.9}`, 32 transitions each. Both sources accept all 864 updates, and all 10,368 compared state/result arrays are exactly equal. Host timestamps and the newly added history field are excluded.
- All 179 tests pass across the four-file panel, including rejection atomicity, pickle continuation, public-update scan, poisoned history, numeric payload accounting, and existing Baird controls. Two trace-recurrence expectations and two injected-history fixtures now use the appropriate incoming discount.
- Ruff, formatting of the new test, strict mypy over 224 source files, and `git diff --check` pass. The five evidence-registry claims retain their pre-existing invalid statuses and identical error lists.

```bash
OMP_NUM_THREADS=1 .venv/bin/python -m pytest \
  tests/test_etd_discount_history.py tests/test_off_policy_td.py \
  tests/test_off_policy_td_update_working_set.py tests/test_baird.py \
  -q -o addopts= --tb=short
PYTHONPATH=. OMP_NUM_THREADS=1 .venv/bin/python /path/to/etd-probe.py \
  --output /new/path/etd-diagnostic.json
```

The standalone probe records source hashes and Git head, writes JSON plus NPZ without overwriting, and uses explicit Threefry keys. Random fixtures have four features, 32 transitions, normal observations scaled by `0.2`, normal rewards scaled by `0.1`, ratios sampled uniformly from `[0.2,1.2)`, interests from `[0.1,1.2)`, and step size `0.01`. All seeds are development seeds; no held-out evaluation or parameter selection occurred.

These are bounded correctness diagnostics, permanently nonpromoting. No benchmark performance, integrated-control benefit, convergence theorem, or scientific evidence is claimed. No pinned output artifact was changed.

[Required CI completed successfully: all 55 jobs passed at this exact head](https://github.com/SlopDotCash/asi/actions/runs/34295839691).

Public proof bundle attached: `etd-incoming-discount.evidence.zip`, 663231 bytes, SHA-256 `7037350b014acfd57e5e6edae33b50ff197bb2e6e1e50852e6cbf66cf415f895`.

The minimized private trace was permanently uploaded and the signed receipt below was finalized after the intake gate recovered. Independent acceptance remains required.

<!-- evidence-head:dd8a5b6f40313d093250514ce09b46625e934165 -->
<!-- evidence-row:logs -->
- [x] logs: [etd-incoming-discount.logs.txt](https://github.com/user-attachments/files/32063741/etd-incoming-discount.logs.txt) (`sha256:f849fdf55213b5f4800613225fc7dbd389e006502660070ba9b6f59d32beddfa`)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: [etd-incoming-discount.evidence.zip](https://github.com/user-attachments/files/32063742/etd-incoming-discount.evidence.zip) (`sha256:7037350b014acfd57e5e6edae33b50ff197bb2e6e1e50852e6cbf66cf415f895`)

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-6
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next26]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-6","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M21RS7FKMHERHAN3CW43STKW","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-09T00:23:45.908Z","completed_at":"2026-09-09T14:03:45.473Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-09T00:23:46.078Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"3d95251b28fa55f87c92ca88832ded4a36c24c1406d85e96bd891f7a0fdd15ca","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"24ca1a48-d92e-4725-9b14-044393c977f8","object_id":"sha256:3d95251b28fa55f87c92ca88832ded4a36c24c1406d85e96bd891f7a0fdd15ca","sha256":"3d95251b28fa55f87c92ca88832ded4a36c24c1406d85e96bd891f7a0fdd15ca"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"uxfQp-ijN1EDRekRE8kdFZYBeBoZUVBQ9B_L2ug7_1ODQvd5SGm9H7eNiS0rKbzZf9xl5dpsnPTuYmwKOOoyCA"}} -->
