### PR TITLE
fix(horde): preserve off-policy credit across discount changes

### DIFF
--- a/alberta_framework/core/off_policy_horde.py
+++ b/alberta_framework/core/off_policy_horde.py
@@ -33,6 +33,7 @@ from alberta_framework.core.multi_head_learner import (
     AnyOptimizer,
     MultiHeadMLPLearner,
     MultiHeadMLPState,
+    _multi_head_update_working_set_bytes,
 )
 from alberta_framework.core.normalizers import (
     EMANormalizerState,
@@ -227,6 +228,24 @@ def _extract_mean_step_size(opt_state: Any) -> Array:
     if hasattr(opt_state, "step_size"):
         return jnp.asarray(opt_state.step_size, dtype=jnp.float32)
     return jnp.array(0.0, dtype=jnp.float32)
+
+
+@chex.dataclass(frozen=True)
+class OffPolicyHordeState(MultiHeadMLPState):
+    """Multi-head state with each demon's last accepted outgoing discount.
+
+    Head traces describe the just-consumed observation, before its outgoing
+    discount. The next accepted update uses that saved discount to carry
+    credit into the new observation. Inactive or rejected heads retain both
+    their trace and discount. Fresh zero traces use an initial discount of 1.
+
+    Legacy ``MultiHeadMLPState`` values lack this history and cannot resume
+    directly. Adopt them explicitly with ``OffPolicyHordeState(**dict(old),
+    previous_discounts=known_history)`` using a float32 vector from the last
+    accepted transition of each head. This does not repair earlier mislearning.
+    """
+
+    previous_discounts: Float[Array, " n_demons"] | None = None
 
 
 @chex.dataclass(frozen=True)
@@ -462,9 +481,22 @@ class OffPolicyHordeLearner:
         """Eligibility-trace ratio clip."""
         return self._trace_ratio_clip
 
-    def init(self, feature_dim: int, key: Array) -> MultiHeadMLPState:
-        """Initialize learner state."""
-        return self._learner.init(feature_dim, key)
+    def init(self, feature_dim: int, key: Array) -> OffPolicyHordeState:
+        """Initialize zero eligibility and explicit per-demon discount history."""
+        feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
+        # Extend the wrapped learner's source/proposed/committed envelope by
+        # the three simultaneously live copies of the new float32 vector.
+        if (
+            _multi_head_update_working_set_bytes(
+                self.n_demons, self._hidden_sizes, feature_dim
+            ) + 12 * self.n_demons > _INT32_MAX
+        ):
+            raise ValueError("off-policy Horde update working set bytes must fit signed int32")
+        base = self._learner.init(feature_dim, key)
+        return OffPolicyHordeState(
+            **dict(cast(Mapping[str, Any], base)),
+            previous_discounts=jnp.ones(self.n_demons, dtype=jnp.float32),
+        )  # type: ignore[call-arg]
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def predict(self, state: MultiHeadMLPState, observation: Array) -> Array:
@@ -542,8 +574,26 @@ class OffPolicyHordeLearner:
         rhos: Array,
         discounts: Array,
     ) -> OffPolicyHordeUpdateResult:
-        """Update using explicit ratios and transition discounts."""
+        """Use outgoing discounts for bootstrap and saved incoming ones for traces.
+
+        Missing or noncanonical discount history requires explicit state
+        adoption; invalid numeric history rejects the whole transaction.
+        """
         n_demons = self.n_demons
+        if not isinstance(state, OffPolicyHordeState):
+            raise ValueError("OffPolicyHordeState with previous_discounts is required")
+        previous_discounts = state.previous_discounts
+        if (
+            not isinstance(previous_discounts, (Array, jax.core.Tracer))
+            or previous_discounts.shape != (n_demons,)
+            or previous_discounts.dtype != jnp.float32
+        ):
+            raise ValueError("previous_discounts must be a float32 vector of length n_demons")
+        history_valid = jnp.all(
+            jnp.isfinite(previous_discounts)
+            & (previous_discounts >= 0.0)
+            & (previous_discounts <= 1.0)
+        )
         replacing = self._trace_mode == TraceMode.REPLACING
         counter_status = self._learner._counter_status(state)
 
@@ -580,7 +630,7 @@ class OffPolicyHordeLearner:
             )
         lamdas = self._horde_spec.lamdas
         head_decay_unused = jnp.all(
-            (discounts == 0.0) | (jnp.asarray(lamdas, dtype=jnp.float32) == 0.0)
+            (previous_discounts == 0.0) | (jnp.asarray(lamdas, dtype=jnp.float32) == 0.0)
         )
         checked_state = checked_state.replace(  # type: ignore[attr-defined]
             head_traces=tuple(
@@ -591,7 +641,7 @@ class OffPolicyHordeLearner:
                 for old_w, old_b in state.head_traces
             )
         )
-        source_state_finite = _floating_tree_is_finite(checked_state)
+        source_state_finite = _floating_tree_is_finite(checked_state) & history_valid
         global_inputs_valid = jnp.all(jnp.isfinite(observation))
         next_observation_valid = jnp.all(jnp.isfinite(next_observation))
         head_inputs_valid = (
@@ -608,7 +658,7 @@ class OffPolicyHordeLearner:
         safe_targets = jnp.where(active_mask, td_targets, 0.0)
         safe_clipped_rhos = jnp.where(active_mask, clipped_rhos, 0.0)
         safe_trace_coefficients = jnp.where(active_mask, trace_coefficients, 0.0)
-        safe_discounts = jnp.where(active_mask, discounts, 0.0)
+        safe_previous_discounts = jnp.where(active_mask, previous_discounts, 0.0)
 
         obs = observation
         new_normalizer_state = state.normalizer_state
@@ -784,7 +834,7 @@ class OffPolicyHordeLearner:
             safe_hidden = jnp.where(active_mask[i], hidden, jnp.zeros_like(hidden))
             w_grad = safe_clipped_rhos[i] * safe_hidden.reshape(1, -1)
             b_grad = safe_clipped_rhos[i] * jnp.ones(1, dtype=jnp.float32)
-            head_gl = safe_discounts[i] * lamdas[i] * safe_trace_coefficients[i]
+            head_gl = safe_previous_discounts[i] * lamdas[i] * safe_trace_coefficients[i]
 
             if replacing:
                 new_w_trace = jnp.where(
@@ -899,7 +949,7 @@ class OffPolicyHordeLearner:
             weights=tuple(new_head_weights),
             biases=tuple(new_head_biases),
         )  # type: ignore[call-arg]
-        new_state = MultiHeadMLPState(
+        new_state = OffPolicyHordeState(
             trunk_params=new_trunk_params,
             head_params=new_head_params,
             trunk_optimizer_states=tuple(new_trunk_opt_states),
@@ -912,6 +962,7 @@ class OffPolicyHordeLearner:
             step_words=counter_status.proposed_step_words,
             birth_timestamp=state.birth_timestamp,
             uptime_s=state.uptime_s,
+            previous_discounts=jnp.where(active_mask, discounts, previous_discounts),
         )  # type: ignore[call-arg]
 
         candidate_state_finite = _floating_tree_is_finite(new_state)
@@ -1678,6 +1729,7 @@ __all__ = [
     "NonlinearSharedGTDHordeUpdateResult",
     "OffPolicyHordeLearner",
     "OffPolicyHordeLearningResult",
+    "OffPolicyHordeState",
     "OffPolicyHordeUpdateResult",
     "run_off_policy_horde_learning_loop",
     "run_off_policy_horde_learning_loop_batched",

--- a/tests/test_off_policy_horde_discount_history.py
+++ b/tests/test_off_policy_horde_discount_history.py
@@ -1,0 +1,224 @@
+"""Changing GVF discounts must preserve credit until the terminating update."""
+
+import pickle
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.core.multi_head_learner import measure_multi_head_mlp_state_nbytes
+from alberta_framework.core.off_policy_horde import (
+    OffPolicyHordeLearner,
+    OffPolicyHordeState,
+    run_off_policy_horde_learning_loop,
+    run_off_policy_horde_learning_loop_batched,
+)
+from alberta_framework.core.optimizers import LMS
+from alberta_framework.core.types import DemonType, GVFSpec, TraceMode, create_horde_spec
+
+
+def _learner(mode=TraceMode.ACCUMULATING, n_demons=1):
+    spec = create_horde_spec(
+        tuple(
+            GVFSpec(
+                name=f"demon_{i}",
+                demon_type=DemonType.PREDICTION,
+                gamma=0.9,
+                lamda=0.8,
+                cumulant_index=i,
+            )
+            for i in range(n_demons)
+        )
+    )
+    return OffPolicyHordeLearner(
+        spec,
+        hidden_sizes=(),
+        optimizer=LMS(step_size=0.1),
+        ratio_clip=10.0,
+        trace_ratio_clip=10.0,
+        trace_mode=mode,
+    )
+
+
+def _initial(learner):
+    state = learner.init(3, jax.random.key(270, impl="threefry2x32"))
+    return state.replace(head_params=jax.tree.map(jnp.zeros_like, state.head_params))
+
+
+def _step(learner, state, index, rewards, discounts, rhos=None):
+    return learner.update_with_ratios_and_discounts(
+        state,
+        jnp.eye(3)[index],
+        jnp.asarray(rewards, dtype=jnp.float32),
+        jnp.eye(3)[(index + 1) % 3],
+        jnp.asarray(rhos if rhos is not None else [1.0] * learner.n_demons, dtype=jnp.float32),
+        jnp.asarray(discounts, dtype=jnp.float32),
+    )
+
+
+@pytest.mark.parametrize("mode", list(TraceMode))
+@pytest.mark.parametrize("incoming", [0.0, 0.5, 0.9])
+@pytest.mark.parametrize("outgoing", [0.0, 0.25, 1.0])
+def test_delayed_credit_uses_incoming_discount(mode, incoming, outgoing):
+    learner = _learner(mode)
+    first = _step(learner, _initial(learner), 0, [0.0], [incoming], [2.0])
+    result = _step(learner, first.state, 1, [1.0], [outgoing], [0.5])
+    assert bool(first.update_applied) and bool(result.update_applied)
+    # rho_1 gamma_1 lambda rho_0 phi_0 + rho_1 phi_1, with delta_1=1.
+    expected = np.array([[0.1 * 0.5 * incoming * 0.8 * 2.0, 0.05, 0.0]])
+    np.testing.assert_allclose(result.state.head_params.weights[0], expected, atol=1e-7)
+
+
+@pytest.mark.parametrize("mode", list(TraceMode))
+def test_terminal_credit_does_not_cross_into_next_episode(mode):
+    learner = _learner(mode)
+    first = _step(learner, _initial(learner), 0, [0.0], [0.5])
+    terminal = _step(learner, first.state, 1, [1.0], [0.0])
+    following = _step(learner, terminal.state, 2, [1.0], [0.9])
+    np.testing.assert_array_equal(
+        following.state.head_params.weights[0][:, :2],
+        terminal.state.head_params.weights[0][:, :2],
+    )
+
+
+def _assert_learning_state_equal(left, right):
+    for name in dict(left):
+        if name in {"birth_timestamp", "uptime_s"}:
+            continue
+        for a, b in zip(
+            jax.tree.leaves(getattr(left, name)), jax.tree.leaves(getattr(right, name)), strict=True
+        ):
+            np.testing.assert_array_equal(a, b)
+
+
+@pytest.mark.parametrize("skipped_reward", [np.nan, np.inf])
+def test_inactive_or_rejected_head_preserves_its_own_discount(skipped_reward):
+    learner = _learner(n_demons=2)
+    first = _step(learner, _initial(learner), 0, [0.0, 0.0], [0.5, 0.9])
+    skipped = _step(learner, first.state, 1, [skipped_reward, 0.0], [0.0, 0.25])
+    np.testing.assert_array_equal(skipped.head_updates_applied, [False, True])
+    np.testing.assert_array_equal(skipped.state.previous_discounts, [0.5, 0.25])
+    np.testing.assert_array_equal(skipped.state.head_traces[0][0], first.state.head_traces[0][0])
+    resumed = _step(learner, skipped.state, 2, [1.0, 1.0], [0.0, 0.0])
+    # Head 0 resumes its last accepted trace; head 1 uses its newer history.
+    np.testing.assert_allclose(resumed.state.head_params.weights[0], [[0.04, 0.0, 0.1]], atol=1e-7)
+    np.testing.assert_allclose(
+        resumed.state.head_params.weights[1], [[0.0144, 0.02, 0.1]], atol=1e-7
+    )
+
+
+def test_global_rejection_and_all_inactive_step_preserve_history():
+    learner = _learner(n_demons=2)
+    first = _step(learner, _initial(learner), 0, [0.0, 0.0], [0.5, 0.9])
+    rejected = learner.update_with_ratios_and_discounts(
+        first.state,
+        jnp.full(3, jnp.inf),
+        jnp.ones(2),
+        jnp.zeros(3),
+        jnp.ones(2),
+        jnp.zeros(2),
+    )
+    assert not bool(rejected.update_applied)
+    _assert_learning_state_equal(rejected.state, first.state)
+    inactive = _step(learner, first.state, 1, [np.nan, np.nan], [0.0, 0.0])
+    assert bool(inactive.update_applied)
+    np.testing.assert_array_equal(inactive.state.previous_discounts, first.state.previous_discounts)
+    assert int(inactive.state.step_count) == int(first.state.step_count) + 1
+
+
+@pytest.mark.parametrize("bad", [-0.1, 1.1, np.nan, np.inf])
+def test_invalid_numeric_history_rejects_atomically(bad):
+    learner = _learner()
+    state = _initial(learner).replace(previous_discounts=jnp.array([bad], dtype=jnp.float32))
+    rejected = _step(learner, state, 0, [1.0], [0.0])
+    assert not bool(rejected.update_applied)
+    _assert_learning_state_equal(rejected.state, state)
+
+
+@pytest.mark.parametrize("bad", [None, jnp.array(0.5), jnp.ones(2), jnp.ones(1, dtype=jnp.int32)])
+def test_missing_or_noncanonical_history_requires_explicit_adoption(bad):
+    learner = _learner()
+    state = _initial(learner).replace(previous_discounts=bad)
+    with pytest.raises(ValueError, match="previous_discounts"):
+        _step(learner, state, 0, [1.0], [0.0])
+
+
+def test_legacy_state_requires_known_history_and_charges_only_one_float_per_demon():
+    learner = _learner(n_demons=2)
+    key = jax.random.key(270, impl="threefry2x32")
+    legacy = learner.learner.init(3, key)
+    with pytest.raises(ValueError, match="previous_discounts"):
+        _step(learner, legacy, 0, [0.0, 0.0], [0.0, 0.0])
+    adopted = OffPolicyHordeState(**dict(legacy), previous_discounts=jnp.ones(2))
+    fresh = learner.init(3, key)
+    _assert_learning_state_equal(adopted, fresh)
+    assert (
+        measure_multi_head_mlp_state_nbytes(fresh)
+        == measure_multi_head_mlp_state_nbytes(legacy) + 8
+    )
+    result = _step(learner, adopted, 0, [0.0, 0.0], [0.0, 0.0])
+    assert bool(result.update_applied)
+
+
+@pytest.mark.parametrize("incoming, accepted", [(0.0, True), (0.5, False)])
+def test_zero_outgoing_discount_does_not_hide_required_poisoned_trace(incoming, accepted):
+    learner = _learner()
+    first = _step(learner, _initial(learner), 0, [0.0], [incoming])
+    state = first.state.replace(head_traces=((jnp.full((1, 3), jnp.inf), jnp.ones(1)),))
+    result = _step(learner, state, 1, [1.0], [0.0])
+    assert bool(result.update_applied) == accepted
+    if accepted:
+        np.testing.assert_array_equal(result.state.head_traces[0][0], [[0.0, 1.0, 0.0]])
+    else:
+        _assert_learning_state_equal(result.state, state)
+
+
+def test_pickle_continuation_and_public_scan_preserve_discount_history():
+    learner = _learner()
+    initial = _initial(learner)
+    first = _step(learner, initial, 0, [0.0], [0.5])
+    restored = pickle.loads(pickle.dumps(first.state))
+    expected = _step(learner, first.state, 1, [1.0], [0.0])
+    actual = _step(learner, restored, 1, [1.0], [0.0])
+    _assert_learning_state_equal(actual.state, expected.state)
+    scanned = run_off_policy_horde_learning_loop(
+        learner,
+        initial,
+        jnp.eye(3)[:2],
+        jnp.array([[0.0], [1.0]]),
+        jnp.eye(3)[1:],
+        jnp.ones((2, 1)),
+        jnp.array([[0.5], [0.0]]),
+    )
+    _assert_learning_state_equal(scanned.state, expected.state)
+    np.testing.assert_array_equal(scanned.updates_applied, [True, True])
+
+
+def test_batched_public_scan_keeps_history_in_its_state():
+    learner = _learner()
+    keys = jax.random.split(jax.random.key(270, impl="threefry2x32"), 2)
+    result = run_off_policy_horde_learning_loop_batched(
+        learner,
+        jnp.eye(3)[:2],
+        jnp.zeros((2, 1)),
+        jnp.eye(3)[1:],
+        jnp.ones((2, 1)),
+        keys,
+        jnp.array([[0.5], [0.0]]),
+    )
+    np.testing.assert_array_equal(result.state.previous_discounts, [[0.0], [0.0]])
+
+
+def test_history_bytes_are_preflighted_before_wrapped_initialization(monkeypatch):
+    import alberta_framework.core.off_policy_horde as module
+
+    learner = _learner(n_demons=2)
+    monkeypatch.setattr(module, "_multi_head_update_working_set_bytes", lambda *args: 2**31 - 20)
+
+    def forbidden(*args):
+        pytest.fail("oversized history envelope reached allocation")
+
+    monkeypatch.setattr(learner.learner, "init", forbidden)
+    with pytest.raises(ValueError, match="working set"):
+        learner.init(3, jax.random.key(270, impl="threefry2x32"))


### PR DESCRIPTION
`OffPolicyHordeLearner.update_with_ratios_and_discounts` uses the outgoing discount to decay an existing head trace. With changing GVF discounts, that drops delayed credit on a terminating transition and carries stale credit into the next episode. This fix saves the last accepted discount independently for each demon, uses it for trace decay, and continues using the current outgoing discount for bootstrap.

For zero initial weights, observations `e0 -> e1 -> e2`, rewards `[0, 1]`, outgoing discounts `[0.5, 0]`, ratios `[2, 0.5]`, lambda `0.8`, and step size `0.1`, the earlier feature's weight is **0 on main, 0.04 with the fix**, matching the analytic recurrence. Both accumulating and replacing traces are covered.

<!-- evidence-head:ea80dc194ab09875eda7e746cd0312d946756bc8 -->

<!-- evidence-row:logs -->
- [x] logs: [off-policy-horde-discount-history.logs.txt](https://github.com/user-attachments/files/32063279/off-policy-horde-discount-history.logs.txt) (`sha256:9d82ea41543463f4280ff58b58a319ab6143b18c464a3d7ffbf2c0a5fec9c6fd`)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: [off-policy-horde-discount-history.evidence.zip](https://github.com/user-attachments/files/32063281/off-policy-horde-discount-history.evidence.zip) (`sha256:a34e67da432bc6adc3bf584367e23eae40c81f0c211d1252f966751ef9cae770`)

**Scope and compatibility.** `OffPolicyHordeState` subclasses the existing `MultiHeadMLPState` and adds one float32 discount per demon. Fresh traces use an initial history of one. Skipped/rejected heads preserve their history; global rejection preserves the entire state. Missing or malformed history requires explicit adoption with the known last accepted discounts; invalid numeric history rejects the transaction. The class docstring documents adoption of legacy states. Adoption cannot repair earlier mislearning. The new vector is included in the wrapped initialization resource envelope. This does not alter the separate nonlinear GTD backend or generic multi-head state schema.

**Correctness reference.** State-dependent return and incoming/outgoing discount indexing follow Section 5, equations (16)–(18), of [Sutton, Mahmood and White (2016)](https://jmlr.org/papers/volume17/14-488/14-488.pdf). This learner remains its existing clipped semi-gradient backend: it does not implement emphatic weighting or inherit that paper's convergence guarantee. Its accumulating head recurrence is `z_t = clip_trace(rho_t) * gamma_t * lambda * z_(t-1) + clip_update(rho_t) * grad_t`; its bootstrap uses `gamma_(t+1)`.

**Bounded paired development check.** Baseline `f3d32c451ed1c1715e477ad56b782fc7ea89b206`; candidate marker above. Three explicit Threefry development seeds `[270, 271, 272]`, no tuning or held-out/promotion seeds. Each seed uses 49 one-hot observations over four features, 48 normal cumulant vectors scaled by 0.1, three demons with lambdas `[0, 0.4, 0.8]`, LMS 0.01, and uniform ratios `[0.2, 2)` with update/trace clips `1.5/1.0`. Both trace modes run the same data. Variable discounts repeat `[[.5,0,.9],[0,.9,.5],[.9,.5,0],[1,.25,.5]]`; constant controls use `0`, `.5`, `.9`. A float64 NumPy recurrence checks every head's parameters and traces after every transition, using tolerances fixed before execution (`atol=2e-6`, `rtol=2e-5`).

| Development seed | Main reference matches / 96 | Candidate / 96 |
|---|---:|---:|
| 270 | 4 | 96 |
| 271 | 2 | 96 |
| 272 | 2 | 96 |
| Mean ± population standard deviation | 2.667 ± 0.943 | 96 ± 0 |

Variable-discount reference matches improve **8/288 to 288/288**. All 864 constant-discount transitions match the reference on both revisions, and **17,280 common saved state arrays are bit-identical**. Maximum candidate absolute error across the panel is `4.0452568583759785e-7`. Both revisions accept all 1,152 transitions. The three-head/four-feature state uses 156→168 JAX-array bytes at initialization and 164→176 after JIT; the eight-byte initialization/update difference is existing host-timing metadata becoming JAX scalar leaves. The new history costs exactly 12 bytes in this example, four per demon. Constant-state equality excludes host birth/uptime telemetry and the new history vector.

**Reproduction commands.** `probe.py` and `compare.py` are included in the attached public evidence bundle; choose new output paths. Baseline and candidate use the same locked project venv (Python 3.12.3, JAX/jaxlib 0.11.0, NumPy 2.5.1).

```bash
.venv/bin/python probe.py --repo <baseline-checkout> --output <new-baseline.json>
.venv/bin/python probe.py --repo <candidate-checkout> --output <new-candidate.json>
.venv/bin/python compare.py --baseline <new-baseline.json> --candidate <new-candidate.json> --output <new-comparison.json>
.venv/bin/python -m pytest tests/test_off_policy_horde_discount_history.py tests/test_off_policy_horde.py tests/test_off_policy_horde_learning_loop_scan_hang.py tests/test_off_policy_horde_zero_ratio.py tests/test_off_policy_horde_update_working_set.py tests/test_baird_horde.py tests/test_multi_head_learner.py -q -o addopts=''
.venv/bin/python -m ruff check .
.venv/bin/python -m mypy
```

Failure-first: 18 failed, 2 passed on main. Initial fixed Horde/Baird panel: 54 passed. Expanded panel initially had 254 passes and one newly added test with incorrectly ordered batched-runner arguments; correcting that test call gives 37/37 focused passes. The final committed-revision panel passes **255 tests in 81.32 seconds**. The exact-head standalone rerun reproduces all paired results; baseline/candidate probe wall times were 3.90/4.95 seconds (telemetry only, not a timing comparison). Ruff, formatting, mypy (224 sources), and diff checks pass. [GitHub CI](https://github.com/SlopDotCash/asi/actions/runs/34298570532) completed successfully at the marked head: **all 55 jobs passed**.

The attached public evidence archive is 659,712 bytes, with SHA-256 `a34e67da432bc6adc3bf584367e23eae40c81f0c211d1252f966751ef9cae770`. Its 12 members and CRCs were verified; it contains no private event trace.

No `outputs/` artifacts were changed or consumed; new raw artifacts are in the attached public bundle. The five evidence-registry claims are already invalid on main and remain invalid with identical errors. This is development-only correctness evidence, permanently nonpromoting, with no claim about learning performance, scientific benefit, or integrated-agent readiness. No long benchmark or new research mechanism was proposed; no thresholds were retuned.

Provider: openai
Model: gpt-6
Client: codex 0.153.4
Run: `run_01M21V2YW0NRRYCWQ3HYGFXB1R` (`asi-queue-next27`; usage unavailable; no usage-log reads or package execution).

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-6
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next27]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-6","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M21V2YW0NRRYCWQ3HYGFXB1R","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-09T01:04:01.921Z","completed_at":"2026-09-10T14:46:42.387Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-09T01:04:02.085Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"309d477bd4b902e2c59855609e9fc3cb07cf911b9442420e0a564bcf648effad","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"119cfadf-5eb2-48ad-aca4-5f8af53111b3","object_id":"sha256:309d477bd4b902e2c59855609e9fc3cb07cf911b9442420e0a564bcf648effad","sha256":"309d477bd4b902e2c59855609e9fc3cb07cf911b9442420e0a564bcf648effad"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"XCvyMk8LyN80Mwa1lc55dELcs5jpfm5wLbkBnrrLvHmW08qTSK8yt1UWR-ArHgH777Ba2tS1EFnfEd-6dJehBA"}} -->
