### PR TITLE
fix(swifttd): preserve bounded updates across finite feature scales

### DIFF
--- a/alberta_framework/core/swift_td.py
+++ b/alberta_framework/core/swift_td.py
@@ -46,6 +46,7 @@ import operator
 from typing import Any, SupportsIndex, cast
 
 import chex
+import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
@@ -103,10 +104,10 @@ def _swift_td_update_result_extras_bytes(feature_dim: int) -> int:
 
 
 def _swift_td_update_working_set_bytes(feature_dim: int) -> int:
-    """Source persist, proposed persist, committed persist, and returned extras."""
+    """Three persist copies, returned extras, and stable-bound scratch space."""
     return 3 * _swift_td_persistent_bytes(
         feature_dim
-    ) + _swift_td_update_result_extras_bytes(feature_dim)
+    ) + _swift_td_update_result_extras_bytes(feature_dim) + 4 * (4 * (feature_dim + 1) + 5)
 
 
 def _preflight_swift_td_update_working_set(feature_dim: int) -> None:
@@ -116,6 +117,46 @@ def _preflight_swift_td_update_working_set(feature_dim: int) -> None:
 
 
 _DEFAULT_ETA_MIN = math.exp(-15.0)
+
+
+def _bounded_trace_increment(
+    log_step_sizes: Array, phi: Array, eta: Array
+) -> tuple[Array, Array, Array]:
+    """Evaluate the existing bound without losing representable increments.
+
+    Keep ordinary arithmetic unchanged. When squared features overflow or
+    the bound times alpha underflows before multiplication by phi, evaluate
+    the same expression in log space. The always-on bias guarantees at least
+    one nonzero feature. The reported scale may itself round to zero even
+    when the complete bounded increment is representable.
+    """
+    alphas = jnp.exp(log_step_sizes)
+    tau = jnp.sum(alphas * phi**2)
+    bound_scale = jnp.minimum(1.0, eta / tau)
+    scaled_alphas = bound_scale * alphas
+    increment = scaled_alphas * phi
+    needs_stable_bound = (
+        ~jnp.isfinite(tau)
+        | ~jnp.all(jnp.isfinite(increment))
+        | jnp.any((scaled_alphas == 0.0) & (phi != 0.0))
+    )
+
+    def stable_bound() -> tuple[Array, Array, Array]:
+        log_abs_phi = jnp.log(jnp.abs(phi))
+        log_energy = log_step_sizes + 2.0 * log_abs_phi
+        peak = jnp.max(log_energy)
+        log_tau = peak + jnp.log(jnp.sum(jnp.exp(log_energy - peak)))
+        log_eta = jnp.log(eta)
+        log_scale = jnp.minimum(0.0, log_eta - log_tau)
+        stable_increment = jnp.sign(phi) * jnp.exp(log_step_sizes + log_abs_phi + log_scale)
+        return stable_increment, jnp.exp(log_scale), log_tau > log_eta
+
+    return cast(
+        tuple[Array, Array, Array],
+        jax.lax.cond(
+            needs_stable_bound, stable_bound, lambda: (increment, bound_scale, tau > eta)
+        ),
+    )
 
 _SUPPORTED_CONFIG_REAL_TYPES: tuple[type[object], ...] = (
     int,
@@ -469,12 +510,11 @@ class SwiftTD:
         # --- Trace extension for phi (second loop of Algorithm 1) ---
         # True Online correction: change the previous update made to V(phi).
         v_delta = jnp.dot(state.prev_weight_update, phi)
-        alphas = jnp.exp(state.log_step_sizes)
         # Correction ratio tau = sum_i alpha_i * phi_i^2; the overshoot bound
         # caps the effective ratio of this update at eta.
-        tau = jnp.sum(alphas * phi**2)
-        bound_scale = jnp.minimum(1.0, eta / tau)
-        z_delta = bound_scale * alphas * phi
+        z_delta, bound_scale, decay_triggered = _bounded_trace_increment(
+            state.log_step_sizes, phi, eta
+        )
         trace_dot = jnp.dot(state.eligibility_traces, phi)
         z_ext = state.eligibility_traces + z_delta * (1.0 - trace_dot)
         p_ext = state.p_traces + state.h_old_traces * phi
@@ -490,11 +530,11 @@ class SwiftTD:
         # Step-size decay: when the bound is active, decay the step-sizes of
         # the features responsible (proportional to phi_i^2) and reset the
         # meta-learning traces.
-        decay_triggered = tau > eta
         log_alphas = jnp.where(
             decay_triggered,
             jnp.clip(
-                state.log_step_sizes + jnp.log(state.step_size_decay) * phi**2,
+                state.log_step_sizes
+                + _skip_zero_scale(jnp.log(state.step_size_decay), phi**2),
                 jnp.log(state.eta_min),
                 jnp.log(eta),
             ),

--- a/tests/test_swift_td_large_observation.py
+++ b/tests/test_swift_td_large_observation.py
@@ -1,0 +1,94 @@
+"""Finite large features must not turn SwiftTD's bound into a zero update."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from alberta_framework.core.learners import TDLinearLearner
+from alberta_framework.core.swift_td import SwiftTD
+
+
+@pytest.mark.parametrize("scale", [1e10, 1e19, 1e20, 1e30])
+@pytest.mark.parametrize("decay", [0.99, 1.0])
+@pytest.mark.parametrize("alpha", [0.01, 1e-30])
+def test_public_learner_preserves_representable_bounded_update(scale, decay, alpha):
+    optimizer = SwiftTD(
+        initial_step_size=alpha,
+        eta=0.1,
+        eta_min=1e-35,
+        meta_step_size=0.0,
+        step_size_decay=decay,
+    )
+    learner = TDLinearLearner(optimizer)
+    state = learner.init(4)
+    obs = jnp.array([scale, -0.5 * scale, 0.0, 0.25 * scale], dtype=jnp.float32)
+    result = jax.jit(learner.update)(state, obs, jnp.array(1.0), jnp.zeros(4), jnp.array(0.0))
+    assert bool(result.update_applied)
+    phi = np.append(np.asarray(obs, dtype=np.float64), 1.0)
+    alphas = np.exp(np.asarray(state.optimizer_state.log_step_sizes, dtype=np.float64))
+    tau = np.sum(alphas * phi**2)
+    expected = min(1.0, float(optimizer.to_config()["eta"]) / tau) * alphas * phi
+    actual = np.append(np.asarray(result.state.weights), float(result.state.bias))
+    # Only require nonzero storage where the mathematical result is normal float32.
+    representable = np.abs(expected) >= np.finfo(np.float32).tiny
+    np.testing.assert_allclose(actual[representable], expected[representable], rtol=3e-5, atol=0)
+    expected_prediction = min(tau, 0.1)
+    prediction = float(jnp.squeeze(learner.predict(result.state, obs)))
+    assert prediction == pytest.approx(expected_prediction, rel=3e-5, abs=1e-15)
+
+
+def test_bound_respects_heterogeneous_step_sizes_and_signed_features():
+    optimizer = SwiftTD(initial_step_size=0.01, eta=0.1, eta_min=1e-35, meta_step_size=0.0)
+    state = optimizer.init(4).replace(
+        log_step_sizes=jnp.log(jnp.array([1e-30, 0.01, 1e-10, 0.1, 1e-3]))
+    )
+    obs = jnp.array([1e30, -1e20, 0.0, 1e10], dtype=jnp.float32)
+    result = jax.jit(optimizer.update)(state, jnp.array(1.0), obs, jnp.zeros(4), jnp.array(0.0))
+    assert bool(result.update_applied)
+    phi = np.append(np.asarray(obs, np.float64), 1.0)
+    alpha = np.exp(np.asarray(state.log_step_sizes, np.float64))
+    expected = float(state.eta) * alpha * phi / np.sum(alpha * phi**2)
+    actual = np.append(np.asarray(result.weight_delta), float(result.bias_delta))
+    normal = np.abs(expected) >= np.finfo(np.float32).tiny
+    np.testing.assert_allclose(actual[normal], expected[normal], rtol=3e-5, atol=0)
+    assert float(result.weight_delta[2]) == 0.0
+
+
+@pytest.mark.parametrize("bad", [np.inf, np.nan])
+def test_stable_bound_still_rejects_nonfinite_observations_atomically(bad):
+    optimizer = SwiftTD(initial_step_size=0.01)
+    state = optimizer.init(2)
+    result = jax.jit(optimizer.update)(
+        state, jnp.array(1.0), jnp.array([1e20, bad]), jnp.zeros(2), jnp.array(0.0)
+    )
+    assert not bool(result.update_applied)
+    for before, after in zip(
+        jax.tree.leaves(state), jax.tree.leaves(result.new_state), strict=True
+    ):
+        np.testing.assert_array_equal(before, after)
+    np.testing.assert_array_equal(result.weight_delta, [0.0, 0.0])
+
+
+@pytest.mark.parametrize("decay", [0.99, 1.0])
+def test_repeated_public_updates_learn_from_large_observation(decay):
+    learner = TDLinearLearner(
+        SwiftTD(
+            initial_step_size=0.01,
+            eta=0.1,
+            eta_min=1e-35,
+            meta_step_size=0.0,
+            trace_decay=0.0,
+            step_size_decay=decay,
+        )
+    )
+    state = learner.init(1)
+    obs = jnp.array([1e20])
+    update = jax.jit(learner.update)
+    for step in range(1, 9):
+        result = update(state, obs, jnp.array(1.0), jnp.zeros(1), jnp.array(0.0))
+        assert bool(result.update_applied)
+        state = result.state
+        assert float(jnp.squeeze(learner.predict(state, obs))) == pytest.approx(
+            1.0 - 0.9**step, rel=3e-5
+        )

--- a/tests/test_swift_td_update_working_set.py
+++ b/tests/test_swift_td_update_working_set.py
@@ -15,8 +15,8 @@ from alberta_framework.core.swift_td import (
 _INT32_MAX = 2**31 - 1
 _INT32_MIN = -(2**31)
 _OVERFLOW_FEATURE_DIM = 30_000_000
-_LAST_FIT_FEATURE_DIM = 21_474_834
-_FIRST_OVERFLOW_FEATURE_DIM = 21_474_835
+_LAST_FIT_FEATURE_DIM = 18_512_788
+_FIRST_OVERFLOW_FEATURE_DIM = 18_512_789
 
 
 def test_int32_wrap_forges_a_different_published_byte_identity() -> None:
@@ -80,6 +80,9 @@ def test_persist_bound_still_fires_before_working_set() -> None:
 def test_legal_small_swift_td_still_updates() -> None:
     persist_bytes = _swift_td_persistent_bytes(5)
     assert persist_bytes == 212
+    # Four augmented fallback buffers and five scalar temporaries are charged
+    # in addition to the original three-state/result envelope.
+    assert _swift_td_update_working_set_bytes(5) == 3 * 212 + 4 * 5 + 29 + 4 * (4 * 6 + 5)
     optimizer = SwiftTD()
     state = optimizer.init(5)
     observation = jnp.zeros((5,), dtype=jnp.float32)


### PR DESCRIPTION
SwiftTD can accept a zero learning update for a finite observation even when the correct bounded update is representable. With zero weights, observation `[1e20]`, reward `1`, gamma `0`, alpha `.01` and eta `.1`, `TDLinearLearner(SwiftTD(...))` changes its prediction by **0 on main instead of .1**. Squared features overflow in `tau = sum(alpha * phi**2)`, or `bound_scale * alpha` underflows before multiplication by a large feature. The no-decay setting also forms `log(1) * inf`, causing valid transitions to be rejected.

This fix evaluates the same bound in log space when those intermediate calculations lose a representable increment. It preserves the ordinary arithmetic path and skips the unused decay product when decay is one. Persistent state and configuration are unchanged. The temporary-memory envelope includes the fallback buffers and rejects the revised adjacent overflow boundary before allocation.

<!-- evidence-head:e8bac6038a6824604faf9ba7bc3ae47e3c5a1297 -->

<!-- evidence-row:logs -->
- [x] logs: [swifttd-finite-scale.logs.txt](https://github.com/user-attachments/files/32061156/swifttd-finite-scale.logs.txt) (`sha256:15803cf94e9742777debc649dbd6c177a8478c4bcc3fce14e403ac4b55d5f423`)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: [swifttd-finite-scale.evidence.zip](https://github.com/user-attachments/files/32061153/swifttd-finite-scale.evidence.zip) (`sha256:2879967f3d70122e4b32145071817e2506b825957592e4707842fd47e2248e7c`)

The mathematical bound is from [SwiftTD, Algorithm 1](https://rlj.cs.umass.edu/2024/papers/RLJ_RLC_2024_111.pdf), specifically the overshoot-bound and step-size-decay lines. This is a numerical rearrangement of the repository's existing transition-phased implementation, not a new learning rule or reproduction of the paper's Atari results. The reported float32 `bound_scale` can itself round to zero while the complete increment remains representable; the fallback computes the complete expression before rounding it. No guarantee is made for increments that cannot be stored by the current float32 backend.

**Paired development arithmetic check.** Baseline `f3d32c451ed1c1715e477ad56b782fc7ea89b206`, candidate at the marker. Explicit Threefry development seeds `[270,271,272]`; no tuning or held-out/promotion seeds. Each seed supplies eight four-feature directions, with positive/negative/zero components. Fresh zero-weight updates cross scales `[1e10,1e19,1e20,1e30]`, initial alphas `[.01,1e-30]`, and decays `[.99,1]`, with eta `.1`, eta_min `1e-35`, meta step size `0`, reward `1`, gamma `0`. Independent float64 arithmetic checks normal-representable update components and prediction changes. Tolerances were fixed before execution: relative `3e-5`, prediction absolute `1e-15`.

| Seed | Main formula matches / 128 | Candidate / 128 |
|---|---:|---:|
| 270 | 32 | 128 |
| 271 | 32 | 128 |
| 272 | 32 | 128 |
| Mean ± population SD | 32 ± 0 | 128 ± 0 |

Matches improve **96/384 to 384/384**. Fresh accepted transitions improve 288/384 to 384/384. Maximum candidate relative error is `1.3959564895138499e-5`, within the fixed tolerance.

The same public learner also retains its state for 16 updates of one `1e20`-scale observation per seed and decay setting. Expected final prediction is `1 - .9**16 = .8146979811`.

| Decay | Main final squared error, mean ± population SD (n=3) | Candidate | Accepted updates, main → candidate |
|---|---:|---:|---:|
| .99 | 1 ± 0 | .03433690456 ± 6.50e-8 | 48 → 48 |
| 1 | 1 ± 0 | .03433654376 ± 1.62e-7 | 0 → 48 |

Ordinary-scale controls use the same three seeds, 32 transitions, lambdas `[0,.8]`, meta step sizes `[0,.001]`, feature multipliers `[1,100]`, and varying discounts `[.9,.5,0,1]`. All **768 control transitions** remain accepted, and **13,056 saved state/metric arrays are bit-identical**, excluding host birth/uptime telemetry. At four features, optimizer persistent storage remains **180 bytes** and the declared update envelope grows **585→685 bytes**. This envelope is source-level accounting, not measured peak device memory. Fallback computation remains linear in feature count. Wall times are telemetry only.

**Reproduction.** The attached evidence bundle contains `probe.py` and `compare.py`; choose new paths for outputs and use one locked project venv for both checkouts (Python3.12.3, JAX/jaxlib0.11.0, NumPy2.5.1).

```bash
.venv/bin/python probe.py --repo <baseline-checkout> --output <new-baseline.json>
.venv/bin/python probe.py --repo <candidate-checkout> --output <new-candidate.json>
.venv/bin/python compare.py --baseline <new-baseline.json> --candidate <new-candidate.json> --output <new-comparison.json>
.venv/bin/python -m pytest tests/test_swift_td_large_observation.py tests/test_swift_td.py tests/test_swift_td_update_working_set.py tests/test_td_optimizers.py -q -o addopts=''
.venv/bin/python -m ruff check .
.venv/bin/python -m mypy
```

Failure-first: **12 failed, 4 passed** on main. Initial fixed panel: 100 passed and one expected resource-endpoint mismatch; that test now asserts the tighter boundary, 18,512,788/18,512,789 features. Expanded panel: **140 passed**. Ruff, new-test formatting, mypy (224 sources), and diff checks pass. The exact committed-head panel also passes **140 tests in 44.08 seconds**, and its standalone rerun reproduces every reported result. [GitHub CI](https://github.com/SlopDotCash/asi/actions/runs/34300746370) completed successfully at the marked head: **all 55 jobs passed**. Probe wall times were 15.54 seconds for main and 17.42 seconds for the candidate; these are telemetry, not a timing comparison.

The attached public archive is 231,363 bytes with 12 integrity-checked members and SHA-256 `2879967f3d70122e4b32145071817e2506b825957592e4707842fd47e2248e7c`. It contains public proof only.

The probe's first invocation failed while modifying a read-only NumPy view of a JAX array; it was changed to a writable copy before any comparison records were produced. No tolerance or mathematical expectation was retuned. Initial inspection found SwiftTD's existing post-update discount decay correct; no discount or trace-timing change is included.

No `outputs/` files or frozen seeds were modified or consumed. The five registry claims were already invalid on main and retain identical status/errors. This is permanently nonpromoting correctness evidence, not a broad benchmark, scientific-performance, or integrated-agent claim.

Provider: openai
Model: gpt-6
Client: codex 0.153.4
Run: `run_01M21WV4WCQRE21S5ZSC7WH10T` (`asi-queue-next28`; usage unavailable; no usage-log reads or usage-package execution).

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-6
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next28]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-6","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M21WV4WCQRE21S5ZSC7WH10T","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-09T01:34:43.085Z","completed_at":"2026-09-10T14:24:26.387Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-09T01:34:43.269Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a4e3f649d0c525d23c87dad5b5b5d083370527f6b0a1a063e3d98d92b4dd7929","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"45330b34-8307-479b-9bde-7fd1ad522eef","object_id":"sha256:a4e3f649d0c525d23c87dad5b5b5d083370527f6b0a1a063e3d98d92b4dd7929","sha256":"a4e3f649d0c525d23c87dad5b5b5d083370527f6b0a1a063e3d98d92b4dd7929"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"ssDbf97iFQeQZZwjyAKWDT7W73ql-EnOFhjVIU4ByApLDiwThcBqpUDaN6PqOk_Niuqe5fVJIY_mR8Y2LBXECQ"}} -->
