### PR TITLE
fix(stomp): preserve valid learning and reject failed planning

### DIFF
--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -977,6 +977,16 @@ def _q_values_for_obs(q_weights: Array, observation: Array) -> Array:
     return q_weights @ observation
 
 
+def _discounted_bootstrap(discount: Array, value: Array) -> Array:
+    """Discard an unused bootstrap before scaling, including an overflowed Q.
+
+    Terminal rewards still train the current state when finite next-state
+    inputs overflow the value prediction. Positive discounts retain the raw
+    prediction; input and source-state validity gates remain the caller's job.
+    """
+    return discount * jnp.where(discount == 0.0, jnp.zeros_like(value), value)
+
+
 _GUMBEL_TIE_BREAK_SCALE = jnp.asarray(1.0e-6, dtype=jnp.float32)
 
 
@@ -1396,7 +1406,7 @@ def _update_intra_option_policy(
     bootstrap_discount = jnp.where(terminated, 0.0, transition_discount).astype(jnp.float32)
 
     q_prev = q_i[last_intra_action] @ last_obs
-    q_next = jnp.max(_q_values_for_obs(q_i, next_obs)) * bootstrap_discount
+    q_next = _discounted_bootstrap(bootstrap_discount, jnp.max(_q_values_for_obs(q_i, next_obs)))
     td_error = pseudo_reward - avg_r_i + q_next - q_prev
 
     alpha = jnp.asarray(step_size, dtype=jnp.float32)
@@ -2104,7 +2114,9 @@ class STOMPAgent:
                 target = (
                     models.env_return_ema[model_idx]
                     - average_reward * models.baseline_mass_ema[model_idx]
-                    + models.discount_ema[model_idx] * jnp.max(eligible_next_q)
+                    + _discounted_bootstrap(
+                        models.discount_ema[model_idx], jnp.max(eligible_next_q)
+                    )
                 )
                 targets = (
                     jnp.full(cfg.n_total_actions, jnp.nan, dtype=jnp.float32)
@@ -2262,7 +2274,9 @@ class STOMPAgent:
         )
         eligible_next_q = jnp.where(action_mask, next_q_values, -jnp.inf)
         td_target = (
-            reward - state.base_average_reward + primitive_discount * jnp.max(eligible_next_q)
+            reward
+            - state.base_average_reward
+            + _discounted_bootstrap(primitive_discount, jnp.max(eligible_next_q))
         )
         targets = (
             jnp.full(
@@ -2762,7 +2776,7 @@ class STOMPAgent:
         ) -> tuple[MultiHeadMLPState, Array, Array, Array]:
             next_q_vals = self._base_learner.predict(state.base_learner_state, bootstrap_obs)
             eligible_next_q = jnp.where(action_mask, next_q_vals, -jnp.inf)
-            max_next_q = base_discount * jnp.max(eligible_next_q)
+            max_next_q = _discounted_bootstrap(base_discount, jnp.max(eligible_next_q))
             td_target = base_reward - state.base_average_reward * base_baseline_mass + max_next_q
             targets = (
                 jnp.full(n_total, jnp.nan, dtype=jnp.float32)

--- a/alberta_framework/core/options.py
+++ b/alberta_framework/core/options.py
@@ -2975,6 +2975,10 @@ class STOMPAgent:
             transaction_preflight
             & intra_update_applied
             & real_base_update_applied
+            # A NaN target is a skipped head to the generic learner, which
+            # still advances its clock. Reject its nonfinite planning result
+            # before those clock increments can certify a successful backup.
+            & jnp.isfinite(planning_td_error)
             & nested_post_matches
             & proposed_state_valid
         )

--- a/alberta_framework/core/prototype_agent.py
+++ b/alberta_framework/core/prototype_agent.py
@@ -3951,6 +3951,17 @@ class PrototypeAgent:
             )
 
         executing = stomp_state.executing_option >= 0
+        if stomp_config.n_options == 0:
+            # lax.cond traces both branches, but a zero-option configuration
+            # has no option-policy row that the unreachable branch can index.
+            gradient_payload = base_source(None)
+        else:
+            gradient_payload = jax.lax.cond(
+                executing,
+                intra_option_source,
+                base_source,
+                operand=None,
+            )
         (
             raw_gradient,
             prediction,
@@ -3960,12 +3971,7 @@ class PrototypeAgent:
             option_terminates,
             parameters_finite,
             source_indices_valid,
-        ) = jax.lax.cond(
-            executing,
-            intra_option_source,
-            base_source,
-            operand=None,
-        )
+        ) = gradient_payload
         inputs_finite = (
             jnp.all(jnp.isfinite(current))
             & jnp.all(jnp.isfinite(bootstrap))

--- a/tests/test_prototype_behavior_gradient_zero_options.py
+++ b/tests/test_prototype_behavior_gradient_zero_options.py
@@ -1,0 +1,100 @@
+"""Prototype behavior gradients must support the zero-option control surface."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.oak import OaKConfig
+from alberta_framework.core.options import STOMPConfig
+from alberta_framework.core.prototype_agent import (
+    PrototypeAgent,
+    PrototypeAgentConfig,
+    PrototypeAgentState,
+    PrototypeTransition,
+)
+from alberta_framework.core.representation_gradient_mixer import (
+    RepresentationGradientMixerConfig,
+)
+from alberta_framework.core.state_builder import OnlineGatedStateBuilderConfig
+
+pytestmark = pytest.mark.unit
+
+
+def _agent() -> PrototypeAgent:
+    builder = OnlineGatedStateBuilderConfig(
+        observation_dim=2,
+        n_actions=1,
+        hidden_dim=1,
+        step_size=0.01,
+    )
+    return PrototypeAgent(
+        PrototypeAgentConfig(
+            oak=OaKConfig(
+                stomp=STOMPConfig(
+                    subtask_specs=(),
+                    observation_dim=builder.feature_dim(),
+                    n_primitive_actions=1,
+                    base_step_size=0.1,
+                    base_avg_reward_step_size=0.0,
+                    epsilon_base=0.0,
+                )
+            ),
+            state_builder=builder,
+            representation_gradient_mixer=RepresentationGradientMixerConfig(
+                representation_dim=builder.feature_dim(),
+                mode="behavior_only",
+            ),
+        )
+    )
+
+
+def _transition(state: PrototypeAgentState) -> PrototypeTransition:
+    return PrototypeTransition(
+        observation=state.current_raw_observation,
+        action=state.current_action,
+        decision_id=state.current_decision_id,
+        reward=jnp.asarray(1.0, dtype=jnp.float32),
+        discount=jnp.asarray(0.9, dtype=jnp.float32),
+        terminated=jnp.asarray(False),
+        truncated=jnp.asarray(False),
+        next_observation=jnp.asarray([0.5, -0.25], dtype=jnp.float32),
+        next_decision_observation=jnp.asarray([0.5, -0.25], dtype=jnp.float32),
+    )
+
+
+def test_behavior_only_mixer_updates_without_an_option_bank() -> None:
+    agent = _agent()
+    state = agent.start(
+        agent.init(jr.key(310, impl="threefry2x32")),
+        jnp.asarray([0.0, 1.0], dtype=jnp.float32),
+    )
+
+    result = agent.update_transition(state, _transition(state))
+
+    assert bool(result.transition_diagnostics.valid)
+    assert bool(result.behavior_gradient_result.valid)
+    assert bool(result.representation_gradient_mix.applied)
+    assert bool(result.state_builder_learning_diagnostics.applied)
+    assert int(result.state.state_builder_state.update_count) == 1
+    assert np.isfinite(np.asarray(result.behavior_representation_gradient)).all()
+
+
+def test_compiled_behavior_only_mixer_updates_without_an_option_bank() -> None:
+    agent = _agent()
+    state = agent.start(
+        agent.init(jr.key(311, impl="threefry2x32")),
+        jnp.asarray([0.25, 0.75], dtype=jnp.float32),
+    )
+
+    result = jax.jit(agent.update_transition)(state, _transition(state))
+
+    assert bool(result.transition_diagnostics.valid)
+    assert bool(result.behavior_gradient_result.valid)
+    assert bool(result.representation_gradient_mix.applied)
+    assert bool(result.state_builder_learning_diagnostics.applied)
+    assert int(result.state.state_builder_state.update_count) == 1
+    assert np.isfinite(np.asarray(result.behavior_representation_gradient)).all()

--- a/tests/test_runtime_profile_json_nest.py
+++ b/tests/test_runtime_profile_json_nest.py
@@ -64,9 +64,11 @@ def test_origin_recursion_class_rejects_before_dumps(
         raise AssertionError("json.dumps ran before the runtime-profile nest gate")
 
     monkeypatch.setattr(json, "dumps", fail_dumps)
+    # Keep fixture allocation and teardown outside the validator's time budget.
+    profile = _nest(16_000)
     started = time.perf_counter()
     with pytest.raises(ValueError, match="nesting depth"):
-        validate_environment_runtime_profile(_nest(16_000))
+        validate_environment_runtime_profile(profile)
     assert time.perf_counter() - started < 0.25
 
 

--- a/tests/test_stomp_planning_transaction.py
+++ b/tests/test_stomp_planning_transaction.py
@@ -1,0 +1,147 @@
+"""Invalid imagined targets must roll back the complete STOMP transition."""
+
+import functools
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.options import STOMPAgent, STOMPConfig, SubtaskSpec
+
+
+@functools.cache
+def _case(backups=1, n_options=1):
+    agent = STOMPAgent(
+        STOMPConfig(
+            subtask_specs=tuple(
+                SubtaskSpec(feature_index=0, threshold=10.0) for _ in range(n_options)
+            ),
+            observation_dim=2,
+            n_primitive_actions=1,
+            base_step_size=0.1,
+            base_avg_reward_step_size=0.1,
+            option_planning_backups_per_step=backups,
+            epsilon_base=0.0,
+        )
+    )
+    state = agent.init(jr.key(270, impl="threefry2x32"))
+    state = state.replace(
+        base_learner_state=state.base_learner_state.replace(
+            head_params=state.base_learner_state.head_params.replace(
+                weights=tuple(jnp.zeros((1, 2)) for _ in range(1 + n_options)),
+                biases=tuple(jnp.zeros(1) for _ in range(1 + n_options)),
+            ),
+            birth_timestamp=jnp.float32(0.0),
+            uptime_s=jnp.float32(0.0),
+        ),
+        base_last_obs=jnp.ones(2),
+        option_models=state.option_models.replace(
+            env_return_ema=jnp.ones(n_options),
+            duration_ema=jnp.ones(n_options),
+            baseline_mass_ema=jnp.ones(n_options),
+            discount_ema=jnp.full(n_options, 0.5),
+            n_completions=jnp.ones(n_options, dtype=jnp.int32),
+            next_state_weights=jnp.full((n_options, 2, 2), 3.0e38),
+        ),
+    )
+    assert bool(agent.state_valid(state))
+    return agent, state
+
+
+def _assert_equal(actual, expected):
+    for a, b in zip(jax.tree.leaves(actual), jax.tree.leaves(expected), strict=True):
+        if jax.dtypes.issubdtype(a.dtype, jax.dtypes.prng_key):
+            a, b = jr.key_data(a), jr.key_data(b)
+        np.testing.assert_array_equal(a, b)
+
+
+@pytest.mark.parametrize("backups", [1, 3])
+@pytest.mark.parametrize("active", [False, True])
+def test_nan_planning_target_cannot_commit_or_advance_lifetime(backups, active):
+    agent, state = _case(backups)
+    if active:
+        state = state.replace(
+            base_last_action=jnp.int32(1),
+            executing_option=jnp.int32(0),
+            option_start_obs=jnp.ones(2),
+        )
+    assert bool(agent.state_valid(state))
+    anchor = jnp.ones(2)
+    predicted_next = anchor + state.option_models.next_state_weights[0] @ anchor
+    assert bool(jnp.all(jnp.isinf(predicted_next)))
+    assert bool(jnp.all(jnp.isnan(agent.base_q_values(state, predicted_next))))
+    result = agent.update(state, jnp.float32(1.0), anchor, jnp.float32(0.5))
+    assert bool(result.inputs_valid)
+    assert bool(result.proposed_state_valid)
+    assert not bool(result.update_applied)
+    assert int(result.planning_backups) == 0
+    assert int(result.nested_updates_applied) == 0
+    assert float(result.planning_td_error) == 0.0
+    _assert_equal(result.state, state)
+
+
+@pytest.mark.parametrize("bad_model", [0, 1])
+def test_one_bad_backup_rolls_back_real_learning_and_other_backups(bad_model):
+    agent, state = _case(backups=2, n_options=2)
+    state = state.replace(
+        option_models=state.option_models.replace(
+            next_state_weights=jnp.zeros((2, 2, 2)).at[bad_model].set(3.0e38),
+        )
+    )
+    result = agent.update(state, jnp.float32(1.0), jnp.ones(2), jnp.float32(0.5))
+    assert not bool(result.update_applied)
+    assert int(result.nested_updates_required) == 3
+    assert int(result.nested_updates_applied) == 0
+    assert int(result.planning_backups) == 0
+    _assert_equal(result.state, state)
+
+
+@pytest.mark.parametrize("disabled", ["zero_budget", "masked", "uncompleted", "flag"])
+def test_unrequested_bad_models_do_not_block_real_learning(disabled):
+    agent, state = _case(backups=0 if disabled == "zero_budget" else 1)
+    if disabled == "uncompleted":
+        state = state.replace(
+            option_models=state.option_models.replace(
+                n_completions=jnp.zeros(1, dtype=jnp.int32),
+            )
+        )
+    result = agent.update(
+        state,
+        jnp.float32(1.0),
+        jnp.ones(2),
+        jnp.float32(0.5),
+        extended_action_mask=jnp.array([True, disabled != "masked"]),
+        enable_planning=disabled != "flag",
+    )
+    assert bool(result.update_applied)
+    assert int(result.planning_backups) == 0
+    assert int(result.nested_updates_applied) == 1
+    assert float(result.state.base_average_reward) == pytest.approx(0.1)
+    assert float(result.state.base_learner_state.head_params.weights[0][0, 0]) == pytest.approx(0.1)
+
+
+def test_rejected_scan_preserves_state_and_can_retry_after_model_repair():
+    agent, state = _case()
+    result = agent.scan(state, jnp.ones(3), jnp.ones((3, 2)), jnp.full(3, 0.5))
+    np.testing.assert_array_equal(result.update_applied, [False, False, False])
+    np.testing.assert_array_equal(result.planning_td_errors, [0.0, 0.0, 0.0])
+    np.testing.assert_array_equal(result.nested_updates_applied, [0, 0, 0])
+    _assert_equal(result.state, state)
+    repaired = result.state.replace(
+        option_models=result.state.option_models.replace(
+            next_state_weights=jnp.zeros((1, 2, 2)),
+        )
+    )
+    retry = agent.update(repaired, jnp.float32(1.0), jnp.ones(2), jnp.float32(0.5))
+    direct = agent.update(
+        state.replace(option_models=repaired.option_models),
+        jnp.float32(1.0),
+        jnp.ones(2),
+        jnp.float32(0.5),
+    )
+    assert bool(retry.update_applied)
+    assert int(retry.nested_updates_applied) == 2
+    assert int(retry.planning_backups) == 1
+    _assert_equal(retry, direct)

--- a/tests/test_stomp_zero_discount_bootstrap.py
+++ b/tests/test_stomp_zero_discount_bootstrap.py
@@ -1,0 +1,270 @@
+"""Terminal STOMP updates must not depend on unused next-state Q values."""
+
+import functools
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.options import STOMPAgent, STOMPConfig, SubtaskSpec
+
+
+def _init(agent):
+    state = agent.init(jr.key(270, impl="threefry2x32"))
+    # Isolate numeric transaction equality from legacy host-clock float32 coercion.
+    return state.replace(
+        base_learner_state=state.base_learner_state.replace(
+            birth_timestamp=jnp.float32(0.0),
+            uptime_s=jnp.float32(0.0),
+        )
+    )
+
+
+@functools.cache
+def _primitive_case(n_options):
+    specs = tuple(
+        SubtaskSpec(feature_index=1, threshold=10.0, max_option_steps=3) for _ in range(n_options)
+    )
+    agent = STOMPAgent(
+        STOMPConfig(
+            subtask_specs=specs,
+            observation_dim=2,
+            n_primitive_actions=1,
+            base_step_size=0.1,
+            base_avg_reward_step_size=0.0,
+            epsilon_base=0.0,
+        )
+    )
+    observation = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    state = _init(agent)
+    params = state.base_learner_state.head_params.replace(
+        weights=tuple(jnp.array([[2.0, 0.0]]) for _ in range(1 + n_options)),
+        biases=tuple(jnp.zeros(1) for _ in range(1 + n_options)),
+    )
+    state = state.replace(
+        base_learner_state=state.base_learner_state.replace(head_params=params),
+        base_last_obs=observation,
+    )
+    assert bool(agent.state_valid(state))
+    return agent, state, observation
+
+
+def _assert_equal(actual, expected):
+    for a, b in zip(
+        jax.tree_util.tree_leaves(actual), jax.tree_util.tree_leaves(expected), strict=True
+    ):
+        if jax.dtypes.issubdtype(a.dtype, jax.dtypes.prng_key):
+            a, b = jr.key_data(a), jr.key_data(b)
+        np.testing.assert_array_equal(a, b)
+
+
+@pytest.mark.parametrize("n_options", [0, 1])
+def test_terminal_primitive_learns_despite_unused_bootstrap_overflow(n_options):
+    agent, state, observation = _primitive_case(n_options)
+    next_observation = jnp.array([3.0e38, 0.0], dtype=jnp.float32)
+    assert bool(
+        jnp.all(jnp.isinf(agent.base_learner.predict(state.base_learner_state, next_observation)))
+    )
+    result = agent.update(
+        state,
+        jnp.float32(1.0),
+        next_observation,
+        jnp.float32(0.0),
+        decision_observation=observation,
+    )
+    control = agent.update(
+        state,
+        jnp.float32(1.0),
+        jnp.zeros(2),
+        jnp.float32(0.0),
+        decision_observation=observation,
+    )
+    assert bool(control.update_applied)
+    assert bool(result.update_applied)
+    assert float(result.td_error) == pytest.approx(1.0)
+    assert float(result.state.base_learner_state.head_params.weights[0][0, 1]) == pytest.approx(0.1)
+    _assert_equal(result, control)
+
+
+@pytest.mark.parametrize("n_options", [0, 1])
+@pytest.mark.parametrize("discount", [1.0e-4, 0.5])
+def test_positive_discount_retains_overflow_rejection(n_options, discount):
+    agent, state, observation = _primitive_case(n_options)
+    result = agent.update(
+        state,
+        jnp.float32(1.0),
+        jnp.array([3.0e38, 0.0]),
+        jnp.float32(discount),
+        decision_observation=observation,
+        execution_boundary=jnp.array(True),
+    )
+    assert not bool(result.update_applied)
+    _assert_equal(result.state, state)
+
+
+@pytest.mark.parametrize("n_options", [0, 1])
+@pytest.mark.parametrize(
+    "bad_input", ["next_observation", "decision_observation", "reward", "state"]
+)
+def test_zero_discount_does_not_relax_finite_input_gates(n_options, bad_input):
+    agent, state, observation = _primitive_case(n_options)
+    next_observation = jnp.array([3.0e38, 0.0])
+    decision_observation = observation
+    reward = jnp.float32(1.0)
+    if bad_input == "next_observation":
+        next_observation = jnp.array([jnp.inf, 0.0])
+    elif bad_input == "decision_observation":
+        decision_observation = jnp.array([jnp.nan, 0.0])
+    elif bad_input == "reward":
+        reward = jnp.float32(jnp.inf)
+    else:
+        state = state.replace(base_average_reward=jnp.float32(jnp.nan))
+    result = agent.update(
+        state,
+        reward,
+        next_observation,
+        jnp.float32(0.0),
+        decision_observation=decision_observation,
+    )
+    assert not bool(result.update_applied)
+    _assert_equal(result.state, state)
+
+
+def test_terminal_scan_keeps_learning_and_matches_safe_bootstrap():
+    agent, state, observation = _primitive_case(0)
+    rewards = jnp.ones(4, dtype=jnp.float32)
+    decisions = jnp.tile(observation, (4, 1))
+    discounts = jnp.zeros(4, dtype=jnp.float32)
+    result = agent.scan(
+        state,
+        rewards,
+        jnp.tile(jnp.array([3.0e38, 0.0]), (4, 1)),
+        discounts,
+        decision_observations=decisions,
+    )
+    control = agent.scan(
+        state,
+        rewards,
+        jnp.zeros((4, 2)),
+        discounts,
+        decision_observations=decisions,
+    )
+    assert bool(jnp.all(result.update_applied))
+    np.testing.assert_allclose(result.td_errors, np.array([1.0, 0.8, 0.64, 0.512]), rtol=1e-6)
+    _assert_equal(result, control)
+
+
+@pytest.mark.parametrize(
+    ("termination", "overflow"),
+    [
+        ("environment", "base"),
+        ("environment", "intra"),
+        ("environment", "both"),
+        ("goal", "intra"),
+        ("duration", "intra"),
+    ],
+)
+def test_completed_option_ignores_unused_bootstrap(termination, overflow):
+    agent = STOMPAgent(
+        STOMPConfig(
+            subtask_specs=(
+                SubtaskSpec(
+                    feature_index=1,
+                    threshold=1.0 if termination == "goal" else 10.0,
+                    max_option_steps=1 if termination == "duration" else 3,
+                ),
+            ),
+            observation_dim=2,
+            n_primitive_actions=1,
+            base_step_size=0.1,
+            base_avg_reward_step_size=0.0,
+            option_step_size=0.1,
+            option_avg_reward_step_size=0.0,
+            epsilon_base=0.0,
+        )
+    )
+    observation = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    state = _init(agent)
+    state = state.replace(
+        base_learner_state=state.base_learner_state.replace(
+            head_params=state.base_learner_state.head_params.replace(
+                weights=tuple(
+                    jnp.array([[2.0 if overflow in ("base", "both") else 0.0, 0.0]])
+                    for _ in range(2)
+                ),
+                biases=(jnp.zeros(1), jnp.zeros(1)),
+            ),
+        ),
+        base_last_obs=observation,
+        base_last_action=jnp.int32(1),
+        executing_option=jnp.int32(0),
+        option_start_obs=observation,
+        option_policies=state.option_policies.replace(
+            q_weights=jnp.array(
+                [[[2.0 if overflow in ("intra", "both") else 0.0, 0.0]]],
+                dtype=jnp.float32,
+            ),
+        ),
+    )
+    assert bool(agent.state_valid(state))
+    result = agent.update(
+        state,
+        jnp.float32(1.0),
+        jnp.array([3.0e38, 1.0]),
+        jnp.float32(0.0 if termination == "environment" else 0.5),
+        decision_observation=observation,
+    )
+    assert bool(result.update_applied)
+    assert bool(result.option_terminated)
+    assert float(result.pseudo_reward) == pytest.approx(1.0)
+    assert float(result.state.option_policies.q_weights[0, 0, 1]) == pytest.approx(0.1)
+    assert int(result.state.option_models.n_completions[0]) == 1
+
+
+@pytest.mark.parametrize("model_discount", [0.0, 0.5])
+def test_terminal_model_planning_ignores_unused_prediction(model_discount):
+    agent = STOMPAgent(
+        STOMPConfig(
+            subtask_specs=(SubtaskSpec(feature_index=1, threshold=10.0),),
+            observation_dim=2,
+            n_primitive_actions=1,
+            base_step_size=0.1,
+            base_avg_reward_step_size=0.0,
+            option_planning_backups_per_step=1,
+            epsilon_base=0.0,
+        )
+    )
+    observation = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    state = _init(agent)
+    state = state.replace(
+        base_learner_state=state.base_learner_state.replace(
+            head_params=state.base_learner_state.head_params.replace(
+                weights=(jnp.array([[2.0, 0.0]]), jnp.array([[2.0, 0.0]])),
+                biases=(jnp.zeros(1), jnp.zeros(1)),
+            ),
+        ),
+        base_last_obs=observation,
+        option_models=state.option_models.replace(
+            env_return_ema=jnp.array([1.0]),
+            duration_ema=jnp.array([1.0]),
+            baseline_mass_ema=jnp.array([1.0]),
+            discount_ema=jnp.array([model_discount]),
+            n_completions=jnp.array([1], dtype=jnp.int32),
+            next_state_weights=jnp.array([[[0.0, 3.0e38], [0.0, 0.0]]]),
+        ),
+    )
+    assert bool(agent.state_valid(state))
+    result = agent.update(state, jnp.float32(0.0), observation, jnp.float32(0.0))
+    assert bool(result.update_applied) == (model_discount == 0.0)
+    if model_discount == 0.0:
+        assert int(result.planning_backups) == 1
+        assert float(result.planning_td_error) == pytest.approx(1.0)
+        assert int(result.state.base_learner_state.step_count) == 2
+        assert float(result.state.base_learner_state.head_params.weights[1][0, 1]) == pytest.approx(
+            0.1
+        )
+    else:
+        assert int(result.state.step_count) == 0
+        _assert_equal(result.state, state)


### PR DESCRIPTION
STOMP can discard valid terminal or zero-option behavior learning, or commit failed planning. A terminal discount forms `0 * inf = NaN`, losing a representable reward update. In model planning, a NaN target is also the generic learner's “skip head” sentinel: its clock still advances, so STOMP can report a successful transaction and planned backups with a NaN diagnostic. With the documented Prototype `behavior_only` representation mixer and no options, JAX traces an unreachable option branch and indexes the empty option-policy bank, so every transition raises `IndexError`.

Discard unused bootstrap values before multiplying by zero in the primitive, extended-action, intra-option, and model-planning paths. Require a finite planning result before the aggregate commits. A failed requested backup now rolls back real learning, other backups, option progress, RNG, and counters together. When the static option count is zero, select the base-control behavior-gradient source without tracing the impossible option branch. Disabled, masked, or uncompleted models remain unused. State, configuration, positive-discount arithmetic, and finite-input validation are unchanged.

<!-- evidence-head:8b92b439eda161ac8d85450fba0ed8a7f9f436b0 -->

**Submission complete.** The immutable public evidence archive is attached, and the permanent private trace upload and signed receipt are finalized.

<!-- evidence-row:logs -->
- [x] logs: [combined public evidence archive](https://github.com/user-attachments/files/32047389/asi-next31-public-evidence.zip); baseline, candidate, and validation logs included.
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: [combined public evidence archive](https://github.com/user-attachments/files/32047389/asi-next31-public-evidence.zip); both standalone probes, raw arrays, and comparisons included.

Attached combined public archive: `asi-next31-public-evidence.zip`, 494,252 bytes, 26 members; SHA-256 `d3648b88a7126eeeb2a02caff6fefcded50cdea8a3dce45f657ece33e337b3e0`. The downloaded attachment is byte-identical to the prepared archive; CRC and exact member contents are verified. It nests the prior archive and adds the zero-option probe, both protocol versions, the retained failed v1 comparison, the accepted v2 comparison, paired leaf manifests, the failure-first log, the 206-test panel, Ruff, mypy, and the final patch. It contains no private trace.

The terminal and planning comparisons use explicit Threefry development seeds `[270,271,272]`, n=3, no tuning or held-out seeds, one locked project venv (Python3.12.3, JAX/jaxlib0.11.0, NumPy2.5.1), and tested STOMP head `8bbd24cb958ae72facff13bddf69de90c289235a`. Expectations were fixed before execution. These are permanently nonpromoting numerical/transaction diagnostics, not benchmark or scientific-performance claims. The final commit only changes Prototype's behavior-gradient source selection and its new regression file; CI validates the combined head.

**Terminal learning.** Compare main `f3d32c451ed1c1715e477ad56b782fc7ea89b206` with tested STOMP head `8bbd24cb958ae72facff13bddf69de90c289235a`. Ordinary weights `[2,0]` and finite final observation `[3e38,0]` overflow an unused next-state value; a distinct finite reset/decision observation `[0,1]` keeps action selection representable. Eight reward draws per seed in `[.75,1.25]` cross eight paths: primitive-only, idle with options, environmental termination with base/intra/both predictions overflowing, goal completion, duration completion, and terminal model planning. Each update must apply, produce finite diagnostics, and match coefficient change `alpha * reward`, alpha `.1`, rtol `2e-6`, atol `1e-7`.

| Seed | Main correct / 64 | Candidate correct / 64 |
|---|---:|---:|
| 270 | 0 | 64 |
| 271 | 0 | 64 |
| 272 | 0 | 64 |
| Mean ± population SD | 0 ± 0 | 64 ± 0 |

Correct terminal updates improve **0/192 → 192/192**. Main rejects 168 and falsely accepts 24 planning cases with NaN diagnostics and no expected weight update. A retained primitive agent then receives 32 terminal reward-one transitions per seed: accepted updates improve **0/96 → 96/96**, final prediction becomes `.9992076755` versus analytic `1-.8**32 = .9992077184`, and final squared error improves **1 ± 0 → 6.2777818144e-7 ± 0**. These retained schedules are identical apart from RNG roots, so the zero spread is not a generalization result.

All **864 ordinary terminal-probe controls** remain accepted; **1,062 saved arrays / 19,860 elements are bit-identical**. Controls cover primitive-only, options, one model backup, lambdas `[0,.7]`, 48 transitions per seed/config, discounts `[.9,.5,0,1]`, boundaries, and separate decision observations.

**Planning atomicity.** Compare the preceding PR head `211fa312bb5fb504d54729e70643896af934e0b8` with tested STOMP head `8bbd24cb958ae72facff13bddf69de90c289235a` to isolate the added commit gate. All supplied state and observations are finite. A completed model's finite `3e38` coefficients overflow its imagined next observation; a zero-weight Q head yields NaN. Six paths cover idle and active options with budgets one/three, plus two-model banks with the bad backup first/last. Eight independent anchor/reward draws per seed give 144 invalid transactions. Success requires exact complete-state rollback, `update_applied=false`, finite zero planning diagnostic, and zero committed backup/update counts—no floating tolerance.

| Seed | Prior PR correct rollbacks / 48 | Candidate / 48 |
|---|---:|---:|
| 270 | 0 | 48 |
| 271 | 0 | 48 |
| 272 | 0 | 48 |
| Mean ± population SD | 0 ± 0 | 48 ± 0 |

False acceptances and published nonfinite diagnostics improve **144 → 0**. The rejected transactions previously reported **288 planning backups / 384 nested updates**; the candidate commits zero. This includes rolling back healthy work staged alongside the bad backup, as required by the aggregate transaction.

All **768 healthy planning-probe controls** remain accepted; **1,464 saved arrays / 18,216 elements are bit-identical**. Controls use `(option count, backup budget)` pairs `[(0,0),(1,1),(1,3),(2,2)]`, lambdas `[0,.7]`, 32 transitions per seed/config, varying discounts, boundaries, and separate decision observations. Canonical state payloads remain **128/220/312 bytes** for zero/one/two options. Both probes set host timing metadata to float32 zero for reproducible numeric equality. Payload counts are not peak-memory measurements; no timing improvement is claimed.

**Zero-option behavior gradients.** Compare preceding PR head `8bbd24cb958ae72facff13bddf69de90c289235a` with final head `8b92b439eda161ac8d85450fba0ed8a7f9f436b0`. The documented `behavior_only` mixer uses an online gated state builder and default `subtask_specs=()`. Across explicit Threefry development seeds `[310,311,312]` in eager and JIT modes, the preceding head raises `IndexError` in **6/6** valid transitions; the final head completes **6/6** valid behavior-gradient mixes and state-builder updates. Each zero-option initial state is 53 numeric leaves / 80 elements / 317 bytes; each successful result is 191 leaves / 222 elements / 594 bytes. No timing claim is made.

All **12 one-option idle/executing controls** succeed at both heads and their directly targeted behavior-gradient payload digests match exactly. The preregistered v1 whole-result cross-process digest gate matched 6/12 and is retained as a failed diagnostic. Repeated same-source whole-state digests were empirically unstable, while paired leaf manifests matched exactly; the amended v2 gate therefore binds the directly changed gradient payload and records why. This is development implementation evidence only.

**Reproduction.** The attached archive separates `terminal/` and `planning/` scripts and records. Use the corresponding baseline above and new output paths:

```bash
.venv/bin/python terminal/probe.py --repo <main-baseline> --output <new-terminal-baseline.json>
.venv/bin/python terminal/probe.py --repo <candidate> --output <new-terminal-candidate.json>
.venv/bin/python terminal/compare.py --baseline <new-terminal-baseline.json> --candidate <new-terminal-candidate.json> --output <new-terminal-comparison.json>
.venv/bin/python planning/probe.py --repo <prior-pr-head> --output <new-planning-baseline.json>
.venv/bin/python planning/probe.py --repo <candidate> --output <new-planning-candidate.json>
.venv/bin/python planning/compare.py --baseline <new-planning-baseline.json> --candidate <new-planning-candidate.json> --output <new-planning-comparison.json>
PYTHONPATH=<prior-pr-worktree> <venv-python> next31/probe/probe.py --label baseline --head 8bbd24cb958ae72facff13bddf69de90c289235a > /tmp/asi-next31-baseline-probe.json
PYTHONPATH=<final-worktree> <venv-python> next31/probe/probe.py --label candidate --head 8b92b439eda161ac8d85450fba0ed8a7f9f436b0 > /tmp/asi-next31-candidate-probe.json
<venv-python> next31/probe/compare-v2.py
.venv/bin/python -m pytest tests/test_prototype_behavior_gradient_zero_options.py tests/test_prototype_state_builder_integration.py tests/test_prototype_gradient_joy.py tests/test_representation_gradient_mixer.py tests/test_representation_gradient_mixer_resource_budget.py tests/test_prototype_transition_contract.py tests/test_stomp_planning_transaction.py tests/test_stomp_zero_discount_bootstrap.py tests/test_runtime_profile_json_nest.py -q -o addopts=''
.venv/bin/python -m ruff check .
.venv/bin/python -m mypy
```

Failure-first: terminal reproduction had six failures and one passing positive-discount rejection; the planning rollback regressions failed on both main and the preceding PR head; the zero-option regression failed twice, eager and compiled, with the same empty-bank `IndexError`. The STOMP head passed its 188-test panel and both standalone comparisons. The final combined head passes a **206-test** focused panel spanning the new path, state-builder integration, Gradient Joy, representation mixing/resource accounting, transition contracts, and every test file changed by this PR. The new focused file passes 2/2. Ruff, mypy (224 sources), and diff checks pass. All **55 jobs pass** in [final-head CI](https://github.com/SlopDotCash/asi/actions/runs/34311553393).

The first [CI run](https://github.com/SlopDotCash/asi/actions/runs/34303191148) exposed the existing `test_origin_recursion_class_rejects_before_dumps` fixture-timing bug: constructing/cleaning a 16,000-level input was included in the `.25s` validator budget. A separate commit reuses the fixture-only fix from #2871. The limit and serialization-order guard remain unchanged; the retained harness check permits a `.3s` fixture delay but still fails a `.3s` validator delay and a serialization bypass. That first run was cancelled after the corrected push. New STOMP test fixtures separately initialize host timestamps to zero to avoid preexisting JIT float32 coercion in exact rollback assertions. No production timing behavior or numerical tolerance was changed.

No `outputs/` artifacts or frozen seeds were modified or consumed. All five registry claims retain their preexisting invalid status/errors. Nonfinite input observations still reject, and zero-discount acceptance does not qualify arbitrary invalid decision states. The planning follow-up strengthens this existing draft; it does not create a separate contribution for the adjacent failure.

Provider: openai
Model: gpt-6
Client: codex 0.153.4
Current run: `run_01M221AZB78VDF5CF2FB5627W9` (`asi-queue-next30`; usage unavailable; no usage-log reads or usage-package execution).
Initial draft run: `run_01M21YYF9NWX5X17ADDJ92PV4Q` (unfinalized; no private upload).

Latest extension provider: openai
Latest extension model: gpt-5
Latest extension client: codex-cli 0.153.4
Latest extension run: `run_01M224R740XCVC5BG7T50CZKT1` (`asi-queue-next31`; completed; usage unavailable; no usage-log reads or usage-package execution).

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next31]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M224R740XCVC5BG7T50CZKT1","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-09T03:52:55.682Z","completed_at":"2026-09-10T07:09:06.474Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-09T03:52:55.900Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"c8cb5e712eac4ff8789531586e1ab2d4129e5561ddb13ad7de7942a623a1614e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"d18ffe66-792a-48c2-b943-1e7cbf89c00c","object_id":"sha256:c8cb5e712eac4ff8789531586e1ab2d4129e5561ddb13ad7de7942a623a1614e","sha256":"c8cb5e712eac4ff8789531586e1ab2d4129e5561ddb13ad7de7942a623a1614e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"bfTS7i8PJno9NAcGTbXcbLino-rbhPYynp0AbqahXfgZ-xXyBPVz7UrbLHzv-YpslAaUm9ZGTnNGk88qnaSHBw"}} -->
