### PR TITLE
fix(world-model): reject malformed latent operands

### DIFF
--- a/alberta_framework/core/latent_world_model.py
+++ b/alberta_framework/core/latent_world_model.py
@@ -117,6 +117,18 @@ def _saturating_int32_increment(value: Array) -> Array:
     return jnp.where(value < maximum, value + jnp.asarray(1, dtype=jnp.int32), maximum)
 
 
+def _float32_operand(
+    name: str,
+    value: Array | float | int,
+    shape: tuple[int, ...],
+) -> Array:
+    """Narrow one numeric operand while preserving its exact shape contract."""
+    array = jnp.asarray(value, dtype=jnp.float32)
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}, got {array.shape}")
+    return array
+
+
 def _latent_direct_state_scalars(
     *,
     observation_dim: int,
@@ -656,7 +668,11 @@ class LatentWorldModel:
         observation: Array,
     ) -> Float[Array, " latent_dim"]:
         """Encode one observation with explicit (differentiable) encoder params."""
-        obs = jnp.asarray(observation, dtype=jnp.float32).reshape((self._config.observation_dim,))
+        obs = _float32_operand(
+            "observation",
+            observation,
+            (self._config.observation_dim,),
+        )
         scale = jnp.asarray(self._observation_scale, dtype=jnp.float32)
         scaled = obs / scale
         return jnp.tanh(scaled @ encoder_matrix + encoder_bias)
@@ -677,7 +693,8 @@ class LatentWorldModel:
         action: Array,
     ) -> Float[Array, " input_dim"]:
         """Return ``concat(latent, one_hot(action), optional interactions)``."""
-        z = jnp.asarray(latent, dtype=jnp.float32).reshape((self._config.latent_dim,))
+        z = _float32_operand("latent", latent, (self._config.latent_dim,))
+        action = _float32_operand("action", action, ())
         safe_action, action_valid = safe_discrete_action(
             action,
             self._config.n_actions,
@@ -736,11 +753,10 @@ class LatentWorldModel:
             next_latent - latent,
             next_latent,
         )
-        reward_target = jnp.reshape(
-            jnp.asarray(reward, dtype=jnp.float32) / self._config.reward_scale,
-            (1,),
-        )
-        discount_target = jnp.reshape(jnp.asarray(discount, dtype=jnp.float32), (1,))
+        reward_arr = _float32_operand("reward", reward, ())
+        discount_arr = _float32_operand("discount", discount, ())
+        reward_target = jnp.reshape(reward_arr / self._config.reward_scale, (1,))
+        discount_target = jnp.reshape(discount_arr, (1,))
         return jnp.concatenate([latent_target, reward_target, discount_target], axis=0)
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -751,7 +767,7 @@ class LatentWorldModel:
         action: Array,
     ) -> LatentWorldModelPrediction:
         """Predict the next latent, reward, and discount from a latent state."""
-        z = jnp.asarray(latent, dtype=jnp.float32).reshape((self._config.latent_dim,))
+        z = _float32_operand("latent", latent, (self._config.latent_dim,))
         raw_predictions = self._learner.predict(
             state.learner_state,
             self.input_features_from_latent(z, action),
@@ -885,17 +901,22 @@ class LatentWorldModel:
         ``encoder_learning=False`` the computation is exactly the
         fixed-encoder path.
         """
-        observation_arr = jnp.asarray(observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
+        observation_arr = _float32_operand(
+            "observation",
+            observation,
+            (self._config.observation_dim,),
         )
+        action = _float32_operand("action", action, ())
         action_arr, action_valid = safe_discrete_action(
             action,
             self._config.n_actions,
         )
-        reward_arr = jnp.asarray(reward, dtype=jnp.float32)
-        discount_arr = jnp.asarray(discount, dtype=jnp.float32)
-        next_observation_arr = jnp.asarray(next_observation, dtype=jnp.float32).reshape(
-            (self._config.observation_dim,)
+        reward_arr = _float32_operand("reward", reward, ())
+        discount_arr = _float32_operand("discount", discount, ())
+        next_observation_arr = _float32_operand(
+            "next_observation",
+            next_observation,
+            (self._config.observation_dim,),
         )
         inputs_valid = (
             jnp.all(jnp.isfinite(observation_arr))

--- a/tests/test_latent_world_model.py
+++ b/tests/test_latent_world_model.py
@@ -7,6 +7,7 @@ import warnings
 from types import MappingProxyType
 
 import chex
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -97,6 +98,141 @@ def test_latent_world_model_update_and_prediction_shapes() -> None:
     chex.assert_shape(result.targets, (7,))
     chex.assert_tree_all_finite(result.surprise)
     chex.assert_tree_all_finite(result.latent_std_mean)
+
+
+@pytest.mark.parametrize("shape", [(1, 2), (2, 1)])
+def test_latent_world_model_rejects_wrong_rank_observation_vectors(
+    shape: tuple[int, int],
+) -> None:
+    """Per-event APIs must not flatten row or column matrices into vectors."""
+    model = LatentWorldModel(
+        LatentWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            latent_dim=2,
+            hidden_sizes=(),
+            sparsity=0.0,
+        )
+    )
+    state = model.init(jr.key(320))
+    observation = jnp.asarray([[0.25, -0.5]], dtype=jnp.float32).reshape(shape)
+    vector = jnp.asarray([0.25, -0.5], dtype=jnp.float32)
+    action = jnp.asarray(1, dtype=jnp.int32)
+    reward = jnp.asarray(0.5, dtype=jnp.float32)
+    discount = jnp.asarray(0.9, dtype=jnp.float32)
+
+    calls = (
+        lambda: model.encode(state, observation),
+        lambda: model.input_features(state, observation, action),
+        lambda: model.targets(state, observation, reward, discount, vector),
+        lambda: model.targets(state, vector, reward, discount, observation),
+        lambda: model.predict(state, observation, action),
+        lambda: model.update(state, observation, action, reward, discount, vector),
+        lambda: model.update(state, vector, action, reward, discount, observation),
+    )
+    for call in calls:
+        with pytest.raises(ValueError, match=r"must have shape \(2,\)"):
+            call()
+        with pytest.raises(ValueError, match=r"must have shape \(2,\)"):
+            jax.jit(call)()
+
+
+@pytest.mark.parametrize("shape", [(1, 2), (2, 1)])
+def test_latent_world_model_rejects_wrong_rank_latent_vectors(
+    shape: tuple[int, int],
+) -> None:
+    model = LatentWorldModel(
+        LatentWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            latent_dim=2,
+            hidden_sizes=(),
+            sparsity=0.0,
+        )
+    )
+    state = model.init(jr.key(321))
+    latent = jnp.asarray([[0.25, -0.5]], dtype=jnp.float32).reshape(shape)
+    action = jnp.asarray(1, dtype=jnp.int32)
+
+    calls = (
+        lambda: model.input_features_from_latent(latent, action),
+        lambda: model.predict_from_latent(state, latent, action),
+    )
+    for call in calls:
+        with pytest.raises(ValueError, match=r"must have shape \(2,\)"):
+            call()
+        with pytest.raises(ValueError, match=r"must have shape \(2,\)"):
+            jax.jit(call)()
+
+
+@pytest.mark.parametrize(
+    ("operation", "field"),
+    [
+        ("input_features_from_latent", "action"),
+        ("input_features", "action"),
+        ("targets", "reward"),
+        ("targets", "discount"),
+        ("predict_from_latent", "action"),
+        ("predict", "action"),
+        ("update", "action"),
+        ("update", "reward"),
+        ("update", "discount"),
+    ],
+)
+def test_latent_world_model_rejects_size_one_scalar_aliases(
+    operation: str,
+    field: str,
+) -> None:
+    model = LatentWorldModel(
+        LatentWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            latent_dim=2,
+            hidden_sizes=(),
+            sparsity=0.0,
+        )
+    )
+    state = model.init(jr.key(322))
+    values = {
+        "observation": jnp.asarray([0.25, -0.5], dtype=jnp.float32),
+        "latent": jnp.asarray([0.1, -0.2], dtype=jnp.float32),
+        "action": jnp.asarray(1, dtype=jnp.int32),
+        "reward": jnp.asarray(0.5, dtype=jnp.float32),
+        "discount": jnp.asarray(0.9, dtype=jnp.float32),
+        "next_observation": jnp.asarray([0.5, 0.75], dtype=jnp.float32),
+    }
+    values[field] = jnp.ones((1,), dtype=jnp.float32)
+
+    def call() -> object:
+        if operation == "input_features_from_latent":
+            return model.input_features_from_latent(values["latent"], values["action"])
+        if operation == "input_features":
+            return model.input_features(state, values["observation"], values["action"])
+        if operation == "targets":
+            return model.targets(
+                state,
+                values["observation"],
+                values["reward"],
+                values["discount"],
+                values["next_observation"],
+            )
+        if operation == "predict_from_latent":
+            return model.predict_from_latent(state, values["latent"], values["action"])
+        if operation == "predict":
+            return model.predict(state, values["observation"], values["action"])
+        return model.update(
+            state,
+            values["observation"],
+            values["action"],
+            values["reward"],
+            values["discount"],
+            values["next_observation"],
+        )
+
+    with pytest.raises(ValueError, match=field):
+        call()
+    with pytest.raises(ValueError, match=field):
+        jax.jit(call)()
 
 
 def test_latent_default_discounts_do_not_inherit_the_reward_dtype() -> None:


### PR DESCRIPTION
The latent world model silently flattened wrong-rank observation and latent arrays whenever their element count happened to match the configured vector width. Size-one action aliases were also accepted, while size-one reward and discount aliases reached the transaction gate as non-scalar predicates and raised a late JAX `TypeError`. A malformed row/column transition could therefore be learned as if it were a valid vector.

Narrow every per-event observation, latent, action, reward, and discount operand to float32 while preserving its exact scalar/vector shape. Wrong-rank inputs now fail at the API boundary in eager and JIT execution. Legal numeric dtypes still canonicalize to float32, and the array-scan contract is unchanged.

<!-- evidence-head:b8949931f586ec6b737ae4b32727334c323673e7 -->

**Public evidence and private receipt are complete.**

<!-- evidence-row:logs -->
- [x] logs: [public evidence archive](https://github.com/user-attachments/files/32053061/asi-next32-public-evidence.zip) (`25,982` bytes; SHA-256 `9eebbb0c9efd050251027b5ed5dcfb24bc31193b867979d25d8a22e73c88c51a`).
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: the same immutable archive contains the manifest, raw paired probes, strict comparison, exact patch, queue epoch, and validation logs.

**Development diagnostic.** The metric is `exact_shape_rejections` in the latent-world-model per-event contract lane. The paired baseline is upstream `main` at `f3d32c451ed1c1715e477ad56b782fc7ea89b206`; the candidate is `b8949931f586ec6b737ae4b32727334c323673e7`. Explicit Threefry development seeds `[320, 321, 322]` (`n=3`) vary initialized learner parameters and valid control operands. These are consumed development seeds only; no tuning/evaluation split or promotion is claimed.

| Metric per seed | Baseline mean ± population SD | Candidate mean ± population SD | Delta |
|---|---:|---:|---:|
| Exact `ValueError` shape rejections / 72 malformed calls | 0 ± 0 | 72 ± 0 | +72 |

Across all 216 eager/JIT calls, the baseline accepted 192 and raised 24 late wrong exception types. Twelve malformed updates per seed committed, **36 total**. The candidate rejects **216/216** at the boundary, raises no late exception type, and commits **0** malformed updates. Healthy transition manifests match byte-for-byte at every seed: 94 numeric leaves, 192 elements, and 744 bytes per result. This is an L0, permanently nonpromoting correctness diagnostic—not model-quality, planning-benefit, scientific-evidence, or performance evidence. No timing claim is made.

Exact diagnostic commands:

```bash
PYTHONPATH=/tmp/asi-next32-baseline /root/asi/.venv/bin/python /tmp/asi-next32-probe.py --label baseline --head f3d32c451ed1c1715e477ad56b782fc7ea89b206 --output /tmp/asi-next32-baseline-detailed.json
PYTHONPATH=/tmp/asi-next32-main /root/asi/.venv/bin/python /tmp/asi-next32-probe.py --label candidate --head b8949931f586ec6b737ae4b32727334c323673e7 --output /tmp/asi-next32-candidate-detailed.json
/root/asi/.venv/bin/python /tmp/asi-next32-compare.py --baseline /tmp/asi-next32-baseline-detailed.json --candidate /tmp/asi-next32-candidate-detailed.json --output /tmp/asi-next32-comparison.json
```

Verification:

```text
/root/asi/.venv/bin/python -m pytest tests/test_latent_world_model.py -q -o addopts=''  # failure-first: 13 failed, 57 passed; candidate: 70 passed
/root/asi/.venv/bin/python -m pytest tests/test_action_conditioned_latent.py tests/test_jepa_transfer_feasibility.py tests/test_late_wave_transactions.py tests/test_latent_world_model.py tests/test_latent_world_model_update_working_set.py tests/test_recurrent_latent_world_model_ensemble.py tests/test_recurrent_latent_world_model_resource_budget.py tests/test_scan_sequence_bounds_validation.py tests/test_world_model_expected_hostile.py -q -o addopts=''  # 283 passed
/root/asi/.venv/bin/python -m ruff check .  # passed
/root/asi/.venv/bin/python -m mypy  # passed, 224 source files
```

GitHub Actions [run 34459529779](https://github.com/SlopDotCash/asi/actions/runs/34459529779) passed all 55 jobs at the exact candidate head, including Python 3.12/3.13 runtime shards, lint, package, robot-floor, and cross-platform jobs.

No `outputs/` artifacts, registered evidence sources, frozen protocols, or held-out seeds were modified. Remaining scope: this fixes the latent model's public per-event operand contract only; it does not change or claim efficacy for its encoder, learner, dreaming policy, or benchmark lanes.

AI provider/model: openai / gpt-5
Client / agent tooling: codex

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next32-corrected]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M25CCWGTN72PGCWAT3QWVB20","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-10T10:04:16.284Z","completed_at":"2026-09-10T10:13:54.071Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-10T10:04:16.607Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"e7f82e1e3aace64aae21803129fa8abca826d8378ea18f4aca509304c0d770c9","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"1288c88a-86c2-456a-aa90-f04dafd2365a","object_id":"sha256:e7f82e1e3aace64aae21803129fa8abca826d8378ea18f4aca509304c0d770c9","sha256":"e7f82e1e3aace64aae21803129fa8abca826d8378ea18f4aca509304c0d770c9"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"Z5Pk1jySwCl84O1fMjfRa1a0lyp35Xc8vcOhN-iQdhRou1-K2q8SoxfOGZEBkoK87ZUlEwznudhdsxb6JisoCA"}} -->
