### PR TITLE
Fix GuardedDreamer uncertainty shape contract

### DIFF
--- a/alberta_framework/core/dreaming.py
+++ b/alberta_framework/core/dreaming.py
@@ -443,6 +443,8 @@ class GuardedDreamer:
         if uncertainty is None:
             uncertainty = jnp.array(0.0, dtype=jnp.float32)
         uncertainty_arr = jnp.asarray(uncertainty, dtype=jnp.float32)
+        if uncertainty_arr.shape != ():
+            raise ValueError("uncertainty must have shape ()")
         prediction = model.predict(model_state, observation, action)
         max_discount = (
             model.config.gamma

--- a/tests/test_action_conditioned_world_model.py
+++ b/tests/test_action_conditioned_world_model.py
@@ -711,6 +711,35 @@ def test_guarded_dreamer_rejects_warmup_and_accepts_after_real_updates() -> None
     chex.assert_shape(warm.transition.next_observation, (2,))
 
 
+@pytest.mark.parametrize("shape", [(1,), (2,), (1, 1)])
+@pytest.mark.parametrize("execution", ["eager", "jit"])
+def test_guarded_dreamer_rejects_nonscalar_uncertainty(
+    shape: tuple[int, ...], execution: str
+) -> None:
+    model = ActionConditionedWorldModel(
+        ActionConditionedWorldModelConfig(
+            observation_dim=2,
+            n_actions=2,
+            hidden_sizes=(),
+        )
+    )
+    model_state = model.init(jr.key(13))
+    dreamer = GuardedDreamer(DreamingConfig())
+    observation = jnp.zeros((2,), dtype=jnp.float32)
+    action = jnp.asarray(0, dtype=jnp.int32)
+    uncertainty = jnp.zeros(shape, dtype=jnp.float32)
+
+    def propose(value: jax.Array) -> object:
+        return dreamer.propose(model, model_state, observation, action, value)
+
+    with pytest.raises(ValueError, match=r"uncertainty must have shape \(\)"):
+        if execution == "eager":
+            with jax.disable_jit():
+                propose(uncertainty)
+        else:
+            jax.jit(propose)(uncertainty)
+
+
 def test_recent_observation_buffer_ring_and_sample() -> None:
     buffer = RecentObservationBuffer(capacity=2, observation_dim=3)
     state = buffer.init()


### PR DESCRIPTION
## Outcome

Fix `GuardedDreamer.propose` so its scalar uncertainty gate cannot emit vector-valued
`DreamProposal.accepted`, `reject_code`, or `uncertainty` fields. Malformed ranks now fail at
the public boundary in eager and JIT execution, before prediction or downstream control flow.

## Reproduction and measured result

Lane: `GuardedDreamer.propose` uncertainty-shape contract.

Metric: malformed uncertainty operands rejected at the API boundary per development seed.
Seeds 330, 331, and 332 are development-only contract-probe seeds (`n=3`), not tuning or
scientific-evaluation seeds. Each seed covers shapes `(1,)`, `(2,)`, and `(1, 1)` under eager
and JIT execution (six cases per seed).

Pre-registered gate: accept only scalar uncertainty in eager and JIT paths; malformed ranks
fail before vector-valued proposal fields; legal scalar proposals remain byte-identical.

| Arm | Mean rejections / 6 | Spread (population SD) | Invalid proposals | Downstream `lax.cond` failures |
| --- | ---: | ---: | ---: | ---: |
| exact-main `f3d32c451ed1c1715e477ad56b782fc7ea89b206` | 0.0 | 0.0 | 6/6 per seed | 6/6 per seed |
| candidate `91a52f59a2fc2a908fccf5d66ccf7c6bc8a58685` | 6.0 | 0.0 | 0/6 per seed | 0/6 per seed |

Paired mean delta: **+6.0 boundary rejections per seed**. All 18 matched legal
default/scalar proposal digests were byte-identical between baseline and candidate. Combined
measured probe wall time was recorded in the attached artifact; both arms used the same CPU
runtime and package environment.

Exact commands:

```bash
PYTHONPATH=/tmp/asi-next33-baseline /root/asi/.venv/bin/python /tmp/asi-next33-measure.py --arm baseline --source-head f3d32c451ed1c1715e477ad56b782fc7ea89b206 --output /tmp/asi-next33-measure-baseline/outputs/guarded_dreamer_uncertainty_shape/baseline.json
PYTHONPATH=/tmp/asi-next33-main /root/asi/.venv/bin/python /tmp/asi-next33-measure.py --arm candidate --source-head 91a52f59a2fc2a908fccf5d66ccf7c6bc8a58685 --output /tmp/asi-next33-measure-candidate-final/outputs/guarded_dreamer_uncertainty_shape/candidate.json
```

Artifact path inside the evidence package:
`outputs/guarded_dreamer_uncertainty_shape/measurement.v1.json`.

This is development-only, permanently nonpromoting correctness evidence. It makes no
learning-quality, performance, robotics-readiness, or scientific claim.

## Verification

- Failure-first focused run: 6 failed, 69 passed (all new malformed-rank cases failed to reject).
- Focused after fix: 75 passed.
- Adjacent dreaming/world-model panel: 167 passed.
- Repository-wide attempt: 885 passed, 3 skipped, then manually interrupted at 4% after
  316.51 seconds because the full scientific/package suite is far beyond this fix's surface.
- `python -m ruff check .`: passed.
- `python -m mypy`: passed, 224 source files.
- Evidence registry remains invalid from pre-existing registered-source drift already present at
  exact main. This patch changes only `core/dreaming.py` and its test; `dreaming.py` is not a
  registered evidence source.

No deviations from the pre-registered measurement gate. The full-suite interruption is stated
above and is not represented as a pass.

## Evidence attachments

<!-- evidence-head:91a52f59a2fc2a908fccf5d66ccf7c6bc8a58685 -->
<!-- evidence-row:logs -->
- [x] logs: [guarded-dreamer-uncertainty-shape.logs.txt](https://github.com/user-attachments/files/32061156/guarded-dreamer-uncertainty-shape.logs.txt) (`sha256:439f68560bd73b5431f41a09d1aee9ffa8ddbfc668641998a433acbe0d0b8fc1`)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: [guarded-dreamer-uncertainty-shape.measurement.v1.json](https://github.com/user-attachments/files/32061161/guarded-dreamer-uncertainty-shape.measurement.v1.json) (`sha256:7f009a7b1e886bc78bdd21e142ac16c2ff69c63bbc9ebb22ae1cde1d5e80e068`)

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [asi-queue-next33]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M25DFDG6VC4GNRXZTKAE3W6N","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-10T10:23:07.784Z","completed_at":"2026-09-10T13:44:02.340Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-10T10:23:08.013Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"37e3d0f11022fa7a3c2292ff9371b554139dbbd9a2c6ae23b08ffa1e6b9f900c","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"f5515a39-0358-4baf-acf3-22309655f515","object_id":"sha256:37e3d0f11022fa7a3c2292ff9371b554139dbbd9a2c6ae23b08ffa1e6b9f900c","sha256":"37e3d0f11022fa7a3c2292ff9371b554139dbbd9a2c6ae23b08ffa1e6b9f900c"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"t4hzzR1hvF4_EgnPL1mlFJctHcAe45BVWhVmtsnbboldZaSM5KrFPCYfz4Os3n-45VUv3XNbCWU2CFuM07jhCw"}} -->
