### PR TITLE
Fix dream rollout scalar channel contract

### DIFF
--- a/alberta_framework/core/dreaming.py
+++ b/alberta_framework/core/dreaming.py
@@ -141,6 +141,12 @@ def _require_bool(value: object, name: str) -> bool:
     return value
 
 
+def _require_scalar_shape(name: str, value: object) -> None:
+    """Reject protocol operands that would broadcast scalar rollout state."""
+    if jnp.asarray(value).shape != ():
+        raise ValueError(f"{name} must be a scalar")
+
+
 @dataclasses.dataclass(frozen=True)
 class DreamingConfig:
     """Configuration for guarded model-generated transitions.
@@ -938,12 +944,24 @@ def dream_one_step(
         rollout_state.observation,
         action_key,
     )
+    _require_scalar_shape(
+        "behavior action_probability",
+        behavior_prediction.action_probability,
+    )
     world_prediction = world_model.predict(
         world_state,
         rollout_state.observation,
         behavior_prediction.action,
         model_key,
     )
+    for name, value in (
+        ("reward", world_prediction.reward),
+        ("discount", world_prediction.discount),
+        ("terminated", world_prediction.terminated),
+        ("confidence", world_prediction.confidence),
+        ("model_error", world_prediction.model_error),
+    ):
+        _require_scalar_shape(name, value)
     confidence_ok = world_prediction.confidence >= jnp.asarray(
         cfg.confidence_threshold,
         dtype=jnp.float32,

--- a/tests/test_dreaming.py
+++ b/tests/test_dreaming.py
@@ -425,6 +425,67 @@ def test_nonfinite_scalar_channels_mark_the_dream_step_invalid(field: str) -> No
     assert not bool(jnp.any(rollout.transitions.valid))
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "field",
+    [
+        "action_probability",
+        "reward",
+        "discount",
+        "terminated",
+        "confidence",
+        "model_error",
+    ],
+)
+@pytest.mark.parametrize("shape", [(1,), (2,), (1, 1)])
+def test_dream_step_rejects_nonscalar_protocol_fields(
+    field: str,
+    shape: tuple[int, ...],
+) -> None:
+    class NonscalarWorldModel(MockWorldModel):
+        def predict(self, state, observation, action, key):  # type: ignore[no-untyped-def]
+            prediction = super().predict(state, observation, action, key)
+            if field == "action_probability":
+                return prediction
+            dtype = jnp.bool_ if field == "terminated" else jnp.float32
+            return dataclasses.replace(
+                prediction,
+                **{field: jnp.ones(shape, dtype=dtype)},
+            )
+
+    class NonscalarBehaviorModel(DeterministicBehaviorModel):
+        def sample_action(self, state, observation, key):  # type: ignore[no-untyped-def]
+            prediction = super().sample_action(state, observation, key)
+            if field != "action_probability":
+                return prediction
+            return dataclasses.replace(
+                prediction,
+                action_probability=jnp.ones(shape, dtype=jnp.float32),
+            )
+
+    world = NonscalarWorldModel()
+    behavior = NonscalarBehaviorModel()
+    world_state = _world_state()
+    behavior_state = DeterministicBehaviorState(action=jnp.array(1, dtype=jnp.int32))
+    initial = init_dream_rollout_state(
+        jnp.array([1.0, 2.0], dtype=jnp.float32),
+        jr.key(340),
+    )
+    message = field.replace("action_probability", "behavior action_probability")
+
+    with pytest.raises(ValueError, match=message):
+        dream_one_step(world, world_state, behavior, behavior_state, initial)
+    with pytest.raises(ValueError, match=message):
+        dream_rollout(
+            world,
+            world_state,
+            behavior,
+            behavior_state,
+            initial,
+            DreamRolloutConfig(rollout_horizon=2),
+        )
+
+
 def test_training_item_conversions_have_expected_targets() -> None:
     world = MockWorldModel()
     behavior = DeterministicBehaviorModel()


### PR DESCRIPTION
## Outcome

Reject nonscalar rollout-protocol channels before they can broadcast scalar dreaming state,
escape in an `ImaginedTransition`, or fail later inside `jax.lax.scan`.

## Reproduced defect and fix

`DreamWorldModelPrediction` declares scalar reward, discount, termination, confidence, and
model-error channels; `DreamBehaviorModelPrediction` likewise declares a scalar action
probability. `dream_one_step` consumed those values without checking rank. A custom model could
therefore return `(1,)`, `(2,)`, or `(1, 1)` arrays and produce vector-valued transition/state
fields. In the scan path, some cases instead failed incidentally when the scalar carry changed
shape.

The fix checks only the static array shape at the public boundary, before gating arithmetic.
It does not cast or otherwise transform legal scalar values.

## Development-only measurement

Metric: correct public-boundary rejections per 36 malformed cases per seed. Development seeds
340–342 (`n=3`) cover six fields, three malformed shapes, and eager plus scan execution. They
are not tuning or scientific-evaluation seeds.

Pre-registered gate: every malformed rank must raise the field-specific boundary error; legal
scalar transition digests must remain identical.

| Arm | Mean correct rejections / 36 | Population SD | Escaped | Incidental scan errors |
| --- | ---: | ---: | ---: | ---: |
| exact main `f3d32c451ed1c1715e477ad56b782fc7ea89b206` | 0.0 | 0.0 | 24/36 per seed | 12/36 per seed |
| candidate `9e0945bfe224dfc1ebd37bf198ff788910eb0e57` | 36.0 | 0.0 | 0/36 per seed | 0/36 per seed |

Paired mean delta: **+36.0 correct boundary rejections per seed**; all three paired legal-output
digests are identical. Both arms used Python 3.12.3, JAX 0.11.1, and NumPy 2.5.2 on the same CPU
runtime.

Exact commands:

```bash
PYTHONPATH=/tmp/asi-next34-baseline OMP_NUM_THREADS=1 /root/asi/.venv/bin/python /tmp/asi-next34-measure.py --arm baseline --source-head f3d32c451ed1c1715e477ad56b782fc7ea89b206 --output /tmp/asi-next34-measure-baseline/baseline.json
PYTHONPATH=/root/asi OMP_NUM_THREADS=1 /root/asi/.venv/bin/python /tmp/asi-next34-measure.py --arm candidate --source-head 9e0945bfe224dfc1ebd37bf198ff788910eb0e57 --output /tmp/asi-next34-measure-candidate-final/candidate.json
```

This is development-only, permanently nonpromoting correctness evidence. It makes no learning,
performance, planning-benefit, robotics-readiness, or scientific claim.

## Verification

- Failure first on exact main: 18 new tests failed; 79 retained tests passed.
- Adjacent action-conditioned/world-model/dreaming panel: 245 passed.
- Step 9, hostile-validation, horizon, lifetime-clock, and Prototype consumer panel: 304 passed.
- Late-wave transaction consumers: 44 passed.
- Ruff passed for both changed files.
- Strict mypy passed for 224 source files.
- `git diff --check f3d32c451ed1c1715e477ad56b782fc7ea89b206..HEAD` passed.
- [Required CI](https://github.com/SlopDotCash/asi/actions/runs/34558087761) passed all 55 jobs on exact head `9e0945bfe224dfc1ebd37bf198ff788910eb0e57`.

The evidence registry remains invalid from pre-existing registered-source drift; this patch does
not touch a source registered by its five claims. `core/dreaming.py` is bound into the unissued,
closed slowly-changing-regression plan, so this commit intentionally changes that plan's current
source identity; no shard or frozen resource was issued or resumed.

## Evidence attachments

<!-- evidence-head:9e0945bfe224dfc1ebd37bf198ff788910eb0e57 -->
<!-- evidence-row:logs -->
- [x] logs: [dream-rollout-scalar-contract.logs.txt](https://github.com/hermesagent270-commits/asi/releases/download/pr-evidence/dream-rollout-scalar-contract.logs.txt) (`sha256:4f3b54737c6feb79604b85605b8cf0401079d4727c7c84051a22a17f6b41a556`)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: [dream-rollout-scalar-contract.measurement.v1.json](https://github.com/hermesagent270-commits/asi/releases/download/pr-evidence/dream-rollout-scalar-contract.measurement.v1.json) (`sha256:2625d9440aca414f5b066196e868bb825c512bdbc6ad8f3e38520afcd8bb643f`)

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [queue-review-20260910]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M25R0C5CYNX369S51YX6DF7W","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-10T13:27:09.229Z","completed_at":"2026-09-11T03:37:33.216Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-10T13:27:09.411Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"6f959fcbd6929024206716a1731db5da2fea4e63acafda5196be553e359d7840","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"0b4df18a-7340-49d3-add4-ce84194e5f4f","object_id":"sha256:6f959fcbd6929024206716a1731db5da2fea4e63acafda5196be553e359d7840","sha256":"6f959fcbd6929024206716a1731db5da2fea4e63acafda5196be553e359d7840"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"O9sfEnipRKOhEUfiLC8l449XcmtQW2b2pR_ba2d-OHm6Z1CA_Q6M11D7VmQ7PRyjUcxW8jmK3HrgRfNEgCIOAw"}} -->
