### PR TITLE
Fix dream rollout next-observation shape contract

### DIFF
--- a/alberta_framework/core/dreaming.py
+++ b/alberta_framework/core/dreaming.py
@@ -944,6 +944,11 @@ def dream_one_step(
         behavior_prediction.action,
         model_key,
     )
+    expected_observation_shape = jnp.asarray(rollout_state.observation).shape
+    if jnp.asarray(world_prediction.next_observation).shape != expected_observation_shape:
+        raise ValueError(
+            f"next_observation must have shape {expected_observation_shape}"
+        )
     confidence_ok = world_prediction.confidence >= jnp.asarray(
         cfg.confidence_threshold,
         dtype=jnp.float32,

--- a/tests/test_dreaming.py
+++ b/tests/test_dreaming.py
@@ -405,6 +405,46 @@ def test_nonfinite_imagined_action_marks_the_dream_step_invalid() -> None:
         assert bool(jnp.all(jnp.isfinite(leaf)))
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize("mode", ["eager", "scan"])
+@pytest.mark.parametrize("shape", [(), (1,), (3,), (2, 1)])
+def test_dream_rollout_rejects_mismatched_next_observation_shape(
+    mode: str,
+    shape: tuple[int, ...],
+) -> None:
+    """A model prediction must preserve the rollout observation shape."""
+
+    class WrongShapeWorldModel(MockWorldModel):
+        def predict(self, state, observation, action, key):  # type: ignore[no-untyped-def]
+            prediction = super().predict(state, observation, action, key)
+            return dataclasses.replace(
+                prediction,
+                next_observation=jnp.zeros(shape, dtype=jnp.float32),
+            )
+
+    world = WrongShapeWorldModel()
+    world_state = _world_state()
+    behavior = DeterministicBehaviorModel()
+    behavior_state = DeterministicBehaviorState(action=jnp.array(1, dtype=jnp.int32))
+    initial = init_dream_rollout_state(
+        jnp.array([1.0, 1.0], dtype=jnp.float32),
+        jr.key(23),
+    )
+
+    with pytest.raises(ValueError, match=r"next_observation must have shape \(2,\)"):
+        if mode == "eager":
+            dream_one_step(world, world_state, behavior, behavior_state, initial)
+        else:
+            dream_rollout(
+                world,
+                world_state,
+                behavior,
+                behavior_state,
+                initial,
+                DreamRolloutConfig(rollout_horizon=2),
+            )
+
+
 @pytest.mark.parametrize("field", ["reward", "discount", "confidence", "model_error"])
 def test_nonfinite_scalar_channels_mark_the_dream_step_invalid(field: str) -> None:
     class ScalarNaNWorldModel(MockWorldModel):


### PR DESCRIPTION
## Defect

`dream_one_step` trusted the world model's `next_observation` shape. A scalar or length-one
prediction broadcast against a vector anchor and escaped as a valid, full-weight imagined
transition. Other mismatches failed only inside JAX broadcasting or `lax.scan` carry validation.
That makes the rollout record and its downstream GVF/SARSA training arrays structurally
untrustworthy.

## Fix

Require `DreamWorldModelPrediction.next_observation` to have exactly the current rollout
observation shape immediately after prediction, before gating arithmetic, broadcasting, state
carry, or training-item construction. The check is static under eager execution and tracing and
does not change legal numeric values.

Regression coverage exercises scalar, length-one, incompatible-vector, and rank-two predictions
through both `dream_one_step` and the scanned `dream_rollout` path.

## Development measurement

Evidence head: `815a88fb01aa74466a5a97543717d78a7989311b`

- Lane: rollout protocol boundary correctness.
- Metric: field-specific public-boundary rejections per 8 malformed cases per seed.
- Development evaluation seeds: 346, 347, 348 (`n=3`); tuning seeds: none.
- Anchor shape: `(2,)`; malformed shapes: `()`, `(1,)`, `(3,)`, `(2,1)`.
- Modes: eager one-step and `lax.scan` rollout.
- Predeclared gate: all malformed cases reject at the boundary and every paired legal-output
  digest remains identical.
- Deviations: none.

| Arm | Mean correct rejections/seed | Population SD | Silent escapes | Incidental errors |
|---|---:|---:|---:|---:|
| exact main `f3d32c451ed1c1715e477ad56b782fc7ea89b206` | 0.0 | 0.0 | 5/8 per seed | 3/8 per seed |
| candidate `815a88fb01aa74466a5a97543717d78a7989311b` | 8.0 | 0.0 | 0/8 per seed | 0/8 per seed |

Paired mean delta: **+8.0 correct boundary rejections per seed**; every seed delta was +8 and
all six paired legal eager/scan output digests were identical. Both arms used Python 3.12.3,
JAX 0.11.1, and NumPy 2.5.2 on the same Linux CPU runtime.

Exact commands:

```bash
PYTHONPATH=/tmp/asi-next35-baseline OMP_NUM_THREADS=1 .venv/bin/python /tmp/asi-next35-measure.py --arm baseline --source-head f3d32c451ed1c1715e477ad56b782fc7ea89b206 --output /tmp/asi-next35-measure-baseline/baseline.json
PYTHONPATH=/root/asi OMP_NUM_THREADS=1 .venv/bin/python /tmp/asi-next35-measure.py --arm candidate --source-head 815a88fb01aa74466a5a97543717d78a7989311b --output /tmp/asi-next35-measure-candidate/candidate.json
```

This is development-only, permanently nonpromoting correctness evidence. It makes no learning,
performance, planning-benefit, robotics-readiness, or scientific claim.

## Verification

- Failure first on exact main: 8 new tests failed; 79 retained tests passed.
- Focused candidate file: 87 passed.
- Adjacent action-conditioned/world-model/dreaming panel: 235 passed.
- Scan, Step 9, horizon, lifetime-clock, hostile-validation, and Prototype consumer panel: 301 passed.
- Ruff passed for both changed files.
- Strict mypy passed for 224 source files.
- `git diff --check f3d32c451ed1c1715e477ad56b782fc7ea89b206..HEAD` passed.
- [Required CI](https://github.com/SlopDotCash/asi/actions/runs/34562374537) passed all
  55 jobs on exact head `815a88fb01aa74466a5a97543717d78a7989311b`.

The evidence registry remains invalid from pre-existing registered-source drift; this patch does
not touch a source registered by its five claims. `core/dreaming.py` is bound into the unissued,
closed slowly-changing-regression plan, so this commit intentionally changes that plan's current
source identity; no plan, reservation, frozen resource, or shard was issued or resumed.

## Evidence attachments

<!-- evidence-head:815a88fb01aa74466a5a97543717d78a7989311b -->
<!-- evidence-row:logs -->
- [x] logs: [dream-rollout-next-observation-shape.logs.txt](https://github.com/hermesagent270-commits/asi/releases/download/pr2880-evidence-815a88fb/dream-rollout-next-observation-shape.logs.txt) (`sha256:3a5651b64bc11be9ecf3b65f944471cd85bbbdd7c86fe7c2f8acbcdf0255640e`)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: [dream-rollout-next-observation-shape.measurement.v1.json](https://github.com/hermesagent270-commits/asi/releases/download/pr2880-evidence-815a88fb/dream-rollout-next-observation-shape.measurement.v1.json) (`sha256:d87c6c2bb4ac75f159d04b2972e9622be70a2c8a452c7259261f718a40e12b00`)

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [queue-review-20260911-next]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M278YWY2W2S3PEZ21BN5M4R5","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-11T03:42:41.092Z","completed_at":"2026-09-11T04:47:31.539Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-11T03:42:41.351Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"01480630333d9a5f68014fe08f41d9a0af266b98cebe7a30185c6d9fef7b5331","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"7cbbab85-723a-48c6-ba05-39d7ac43e15e","object_id":"sha256:01480630333d9a5f68014fe08f41d9a0af266b98cebe7a30185c6d9fef7b5331","sha256":"01480630333d9a5f68014fe08f41d9a0af266b98cebe7a30185c6d9fef7b5331"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"3OkT9Sl1xar6y00BRv4pwT2TyJxFohZm2DoTmhHgMpHvX9rc-9Git4ZIPpPY4RC67gRg3csksFmGUtzxJRTrDw"}} -->
