### PR TITLE
fix(features): bind learner RNG to Threefry

### DIFF
--- a/alberta_framework/core/feature_discovery.py
+++ b/alberta_framework/core/feature_discovery.py
@@ -73,6 +73,23 @@ def _require_int32(name: str, value: object, *, minimum: int) -> int:
     return canonical
 
 
+def _require_typed_threefry_key(name: str, value: object) -> Array:
+    """Require one scalar typed Threefry key without accepting legacy key data."""
+    actual_type = type(value)
+    if not (
+        issubclass(actual_type, jax.Array) or issubclass(actual_type, jax.core.Tracer)
+    ):
+        raise TypeError(f"{name} must be a scalar typed Threefry JAX key")
+    trusted = cast(Array, value)
+    try:
+        words = jr.key_data(trusted)
+    except (TypeError, ValueError) as error:
+        raise TypeError(f"{name} must be a scalar typed Threefry JAX key") from error
+    if trusted.shape != () or words.shape != (2,) or words.dtype != jnp.dtype(jnp.uint32):
+        raise TypeError(f"{name} must be a scalar typed Threefry JAX key")
+    return trusted
+
+
 def _require_feature_discovery_loop_steps(name: str, value: object) -> int:
     """Reject scan lengths above the public last-fit before ``jnp.arange``."""
     return require_scan_steps(name, value, _FEATURE_DISCOVERY_LOOP_BUDGET)
@@ -649,6 +666,7 @@ class FixedBudgetFeatureLearner:
         """Initialize active and candidate feature banks."""
         feature_dim = _require_int32("feature_dim", feature_dim, minimum=1)
         self._configured_state_nbytes(feature_dim)
+        key = _require_typed_threefry_key("FixedBudgetFeatureLearner key", key)
         key, k_active, k_candidate = jr.split(key, 3)
         scale = self._init_scale / jnp.sqrt(float(feature_dim))
         feature_weights = scale * jr.normal(
@@ -728,6 +746,7 @@ class FixedBudgetFeatureLearner:
         """Fail while tracing before broadcasting or dtype promotion can occur."""
         if state.feature_weights.ndim != 2:
             raise ValueError("state.feature_weights must be a rank-2 array")
+        _require_typed_threefry_key("state.key", state.key)
         feature_dim = state.feature_weights.shape[1]
         float_shapes = {
             "feature_weights": (self._n_features, feature_dim),

--- a/tests/test_feature_discovery_hostile_validation.py
+++ b/tests/test_feature_discovery_hostile_validation.py
@@ -6,6 +6,7 @@ import jax.random as jr
 import numpy as np
 import pytest
 
+from alberta_framework.core.feature_discovery import FixedBudgetFeatureLearner
 from alberta_framework.streams.feature_discovery import (
     InteractionFeatureDiscoveryStream,
     NonlinearFeatureDiscoveryStream,
@@ -349,6 +350,47 @@ def test_init_requires_scalar_typed_threefry_key(
     for bad in (jnp.asarray([0, 1], dtype=jnp.uint32), jnp.asarray(0, dtype=jnp.int32)):
         with pytest.raises(TypeError, match="Threefry"):
             stream.init(bad)
+
+
+@pytest.mark.parametrize(
+    "bad_key",
+    [
+        jnp.asarray([0, 1], dtype=jnp.uint32),
+        jr.key(1, impl="rbg"),
+        jr.split(jr.key(1, impl="threefry2x32"), 1),
+    ],
+)
+def test_fixed_budget_feature_learner_init_requires_scalar_typed_threefry_key(
+    bad_key: jax.Array,
+) -> None:
+    learner = FixedBudgetFeatureLearner(n_features=2, n_tasks=1, candidate_count=1)
+
+    with pytest.raises(TypeError, match="FixedBudgetFeatureLearner key.*Threefry"):
+        learner.init(feature_dim=3, key=bad_key)
+
+
+@pytest.mark.parametrize(
+    "bad_key",
+    [
+        jnp.asarray([0, 1], dtype=jnp.uint32),
+        jr.key(1, impl="rbg"),
+        jr.split(jr.key(1, impl="threefry2x32"), 1),
+    ],
+)
+def test_fixed_budget_feature_learner_update_rejects_non_threefry_state_key(
+    bad_key: jax.Array,
+) -> None:
+    learner = FixedBudgetFeatureLearner(n_features=2, n_tasks=1, candidate_count=1)
+    state = learner.init(feature_dim=3, key=jr.key(2, impl="threefry2x32")).replace(
+        key=bad_key
+    )
+
+    with pytest.raises(TypeError, match="state.key.*Threefry"):
+        learner.update(
+            state,
+            jnp.ones(3, dtype=jnp.float32),
+            jnp.ones(1, dtype=jnp.float32),
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Outcome

Fix the feature-discovery learner's RNG boundary so every stochastic learner state is
rooted in a scalar typed Threefry key, as required by ASI's explicit-RNG contract.

`FixedBudgetFeatureLearner.init` previously accepted legacy `uint32[2]` keys and typed
RBG keys silently. The former depended on JAX's ambient default PRNG implementation;
the latter changed both the random stream and the persistent key payload from 8 to 16
bytes. Batched typed Threefry keys escaped the boundary and failed later inside
`jax.random.split` with an incidental error. Forged states could reach `update` with the
same invalid key forms.

This change adds one fail-closed validator at `init` and the shared static state-contract
boundary. It accepts only scalar typed Threefry keys whose key data is exactly two
`uint32` words. It intentionally preserves the legal-key computation and public import
surface.

Candidate head: `cb2037391e7a4a61328fd6a0190418c26926bb8e`
Baseline head: `f3d32c451ed1c1715e477ad56b782fc7ea89b206`

<!-- evidence-head:cb2037391e7a4a61328fd6a0190418c26926bb8e -->

## Development measurement

Pre-registered before execution: seeds 349–351 (`n=3`, no tuning); three malformed key
classes (legacy `uint32[2]`, typed RBG, batched typed Threefry) at both `init` and
`update`; pass only if all 6 cases per seed are rejected at the named boundary, with no
silent escape or incidental downstream error, and the legal typed-Threefry init/update
digest remains bit-identical between arms.

| Metric | Exact `main` baseline | Candidate | Paired delta |
|---|---:|---:|---:|
| Correct boundary rejections / seed (mean ± population SD) | 0.0 ± 0.0 | 6.0 ± 0.0 | +6.0 |
| Correct boundary rejections (total) | 0 / 18 | 18 / 18 | +18 |
| Silent invalid-key escapes | 12 | 0 | -12 |
| Incidental downstream errors | 6 | 0 | -6 |
| Legal digest matches | 3 / 3 | 3 / 3 | unchanged |

Gate: **PASS**. All legal updates applied, and the legal stored key remained two `uint32`
words (8 bytes). This is development-only and permanently nonpromoting; it creates no
performance or scientific evidence.

Artifact path: `outputs/feature_discovery_threefry_contract/measurement.v1.json`.
Deviations from pre-registration: none. Remaining scope: this validates only the
feature-discovery learner boundary; it does not establish a general cross-module RNG
conformance result.

Environment: Python 3.12.3, JAX 0.11.1, NumPy 2.5.2, Linux CPU,
`OMP_NUM_THREADS=1`.

Exact commands:

```text
PYTHONPATH=/tmp/asi-next36-baseline-src OMP_NUM_THREADS=1 .venv/bin/python /tmp/asi-next36-measure.py --arm baseline --source-head f3d32c451ed1c1715e477ad56b782fc7ea89b206 --output /tmp/asi-next36-measure-baseline/baseline.json
PYTHONPATH=/root/asi OMP_NUM_THREADS=1 .venv/bin/python /tmp/asi-next36-measure.py --arm candidate --source-head cb2037391e7a4a61328fd6a0190418c26926bb8e --output /tmp/asi-next36-measure-candidate/candidate.json
```

## Verification

- Failing-test-first on exact baseline with test-only patch: `6 failed, 38 passed`
  (4 silent escapes, 2 incidental JAX errors).
- Focused hostile validation: `44 passed`.
- Owned feature-discovery panel: `207 passed`.
- Adjacent future-utility/nonfinite transaction panel: `111 passed`.
- Ruff over `alberta_framework` and `tests`: passed.
- Strict mypy: passed over 224 source files.
- `git diff --check origin/main..HEAD`: passed.

## Evidence scope

The changed production file is not in the five-claim registered-source inventory.
`alberta-evidence-status` still exits 2 from pre-existing registered-source drift; this
change does not silence or alter it. Historical Forager and closed
slowly-changing-regression manifests that inventory this source remain untouched; their
stored identities do not describe this candidate. No output artifact, frozen seed, claim,
or reference configuration was modified or promoted.

## Immutable attachments

<!-- evidence-row:logs -->
- [x] logs: [verification log](https://github.com/user-attachments/assets/11fbc706-d063-4ee9-8b09-62af1c81c568)
  (SHA-256 `67f1429d48aed306c98fc7614b856e1a76c3807850e89f070046176d93b43772`,
  3,345 bytes)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: [matched measurement artifact](https://github.com/user-attachments/assets/ba1d2d40-b107-4aa1-8ac7-b3ddce442737)
  (SHA-256 `a06bfd2503ae23af35808316bf1744db01ac4228846f72f2d632746ffcaa3004`,
  16,193 bytes)

GitHub CLI currently accepts only media at its immutable attachment endpoint, so each
linked SVG is a self-describing envelope whose `payload` metadata element contains the
exact named payload as base64. Decode that element and verify the stated byte count and
SHA-256; the envelopes were round-trip checked before upload.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [queue-review-20260911-next36]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M27D165QPDQZGRD9JV1HX8ME","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-11T04:53:50.393Z","completed_at":"2026-09-11T13:08:16.846Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-11T04:53:50.588Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"3179498584063e14fdb16ae034032510a16f0222af54db470f09183005befb19","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"88758077-49c6-4295-9f0b-967712bec333","object_id":"sha256:3179498584063e14fdb16ae034032510a16f0222af54db470f09183005befb19","sha256":"3179498584063e14fdb16ae034032510a16f0222af54db470f09183005befb19"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"N1L4YUG4iU-M6j6xbPOqgMyEE4aDo7VKpW7iwAJO9mQ5QD_tKsVY3HHqeWU-R_uwfT6dAF2gCT5GMLU7mTk7Cw"}} -->
