### PR TITLE
fix(behavior): bind RNG budget to Threefry

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -63,6 +63,29 @@ def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
     return validated_float32_scalar(name, value, **bounds)
 
 
+def _require_typed_threefry_key(name: str, value: object) -> Array:
+    """Require one scalar typed Threefry key with exactly two uint32 words."""
+    actual_type = type(value)
+    if not (
+        issubclass(actual_type, jax.Array) or issubclass(actual_type, jax.core.Tracer)
+    ):
+        raise TypeError(f"{name} must be a scalar typed Threefry JAX key")
+    trusted = cast(Array, value)
+    try:
+        implementation = str(jr.key_impl(trusted))
+        words = jr.key_data(trusted)
+    except (TypeError, ValueError) as error:
+        raise TypeError(f"{name} must be a scalar typed Threefry JAX key") from error
+    if (
+        trusted.shape != ()
+        or implementation != "threefry2x32"
+        or words.shape != (2,)
+        or words.dtype != jnp.dtype(jnp.uint32)
+    ):
+        raise TypeError(f"{name} must be a scalar typed Threefry JAX key")
+    return trusted
+
+
 def _resource_counts(n_actions: int, feature_dim: int) -> tuple[int, int]:
     """Return exact trainable scalars and bytes, rejecting unsafe derived counts."""
     trainable = n_actions * feature_dim + n_actions
@@ -633,6 +656,7 @@ class BehaviorModel:
             self._config.n_actions,
             feature_dim,
         )
+        key = _require_typed_threefry_key("key", key)
         return BehaviorModelState(
             weights=jnp.zeros(
                 (self._config.n_actions, feature_dim),
@@ -959,6 +983,7 @@ class BehaviorModel:
         observation: Array,
     ) -> BehaviorModelSampleResult:
         """Sample one action from the learned behavior distribution."""
+        _require_typed_threefry_key("state.rng_key", state.rng_key)
         key, sample_key = jr.split(state.rng_key)
         probabilities = floor_and_renormalize_probabilities(
             self.predict_probabilities(state, observation),

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -337,6 +337,41 @@ def test_resource_budget_matches_initialized_state_arrays_exactly() -> None:
     assert budget.to_dict()["state_nbytes"] == actual_nbytes
 
 
+@pytest.mark.parametrize(
+    "key",
+    (
+        jax.random.PRNGKey(13),
+        jax.random.key(13, impl="rbg"),
+        jax.random.split(jax.random.key(13, impl="threefry2x32"), 1),
+    ),
+)
+def test_behavior_model_init_requires_scalar_typed_threefry_key(key: jax.Array) -> None:
+    model = BehaviorModel(BehaviorModelConfig(n_actions=3))
+
+    with pytest.raises(TypeError, match="scalar typed Threefry"):
+        model.init(feature_dim=4, key=key)
+
+
+@pytest.mark.parametrize(
+    "key",
+    (
+        jax.random.PRNGKey(17),
+        jax.random.key(17, impl="rbg"),
+        jax.random.split(jax.random.key(17, impl="threefry2x32"), 1),
+    ),
+)
+def test_behavior_model_sampling_requires_scalar_typed_threefry_state_key(
+    key: jax.Array,
+) -> None:
+    model = BehaviorModel(BehaviorModelConfig(n_actions=3))
+    state = model.init(feature_dim=4, key=jax.random.key(17, impl="threefry2x32")).replace(
+        rng_key=key
+    )
+
+    with pytest.raises(TypeError, match="state.rng_key must be a scalar typed Threefry"):
+        model.sample_action(state, jnp.ones((4,), dtype=jnp.float32))
+
+
 def test_preupdate_input_gradient_matches_autodiff_and_does_not_advance_state() -> None:
     model = BehaviorModel(
         BehaviorModelConfig(
@@ -899,4 +934,3 @@ def test_floor_and_renormalize_probabilities_returns_simplex_on_zero_and_extreme
         out = floor_and_renormalize_probabilities(jnp.asarray(probs, dtype=jnp.float32))
         np.testing.assert_allclose(float(jnp.sum(out)), 1.0, atol=1e-5)
         assert np.all(np.asarray(out) >= 1e-6)
-


### PR DESCRIPTION
## Outcome

Bind `BehaviorModel`'s stochastic state to the scalar typed Threefry key shape already
assumed by its exact resource budget.

`BehaviorModel.init` previously accepted legacy `uint32[2]`, typed RBG, and batched
typed Threefry keys. The RBG form made the persisted state 92 bytes while
`resource_budget()` reported 84; legacy and RBG keys also passed through
`sample_action`, while a batched key failed only later inside `jax.random.split`.

This change adds one fail-closed validator at `init` and `sample_action`. It accepts only
scalar typed Threefry keys backed by exactly two `uint32` words, preserving legal-key
behavior and the public import surface.

Candidate head: `05205eaf790c7f4c5f17dcdaadb2a391b21839dd`
Baseline head: `f3d32c451ed1c1715e477ad56b782fc7ea89b206`

<!-- evidence-head:05205eaf790c7f4c5f17dcdaadb2a391b21839dd -->

## Development measurement

Pre-registered before execution: seeds 352–354 (`n=3`, no tuning); three malformed key
classes (legacy `uint32[2]`, typed RBG, batched typed Threefry) at both `init` and
`sample_action`; pass only if all 6 cases per seed are rejected at the named boundary,
the legal typed-Threefry digest remains bit-identical between arms, and legal state bytes
equal the public resource budget.

| Metric | Exact `main` baseline | Candidate | Paired delta |
|---|---:|---:|---:|
| Correct boundary rejections / seed (mean ± population SD) | 0.0 ± 0.0 | 6.0 ± 0.0 | +6.0 |
| Correct boundary rejections (total) | 0 / 18 | 18 / 18 | +18 |
| Silent invalid-key escapes | 15 | 0 | -15 |
| Incidental downstream errors | 3 | 0 | -3 |
| Legal digest matches | 3 / 3 | 3 / 3 | unchanged |
| Legal state / reported budget | 84 / 84 bytes | 84 / 84 bytes | unchanged |

Gate: **PASS**. The exact-main RBG cases stored 92-byte states against the 84-byte
budget (+8 bytes); the candidate rejects them at the boundary. This is development-only
and permanently nonpromoting; it creates no performance or scientific evidence.

Artifact path: `outputs/behavior_model_threefry_budget/measurement.v1.json`.
Deviations from pre-registration: none. Remaining scope: this validates only the
`BehaviorModel` key boundary and its stated state-byte budget; it is not a general
cross-module RNG conformance result.

Environment: Python 3.12.3, JAX 0.11.1, NumPy 2.5.2, Linux CPU,
`OMP_NUM_THREADS=1`.

Exact commands:

```text
PYTHONPATH=/tmp/asi-next37-baseline-src OMP_NUM_THREADS=1 .venv/bin/python /tmp/asi-next37-measure.py --arm baseline --source-head f3d32c451ed1c1715e477ad56b782fc7ea89b206 --output /tmp/asi-next37-measure-baseline/baseline.json
PYTHONPATH=/root/asi OMP_NUM_THREADS=1 .venv/bin/python /tmp/asi-next37-measure.py --arm candidate --source-head 05205eaf790c7f4c5f17dcdaadb2a391b21839dd --output /tmp/asi-next37-measure-candidate/candidate.json
```

## Verification

- Failing-test-first on exact baseline with test-only patch: `6 failed, 66 deselected`
  (5 silent escapes per seed class, with the batched sampling case failing incidentally).
- Focused malformed-key tests: `6 passed, 66 deselected`.
- Owned BehaviorModel panel: `87 passed`.
- Adjacent world-model/dreaming/RNG panel: `305 passed`.
- Ruff over both changed files: passed.
- Strict mypy: passed over 224 source files.
- `git diff --check origin/main..HEAD`: passed.

Full-tree Ruff is not a clean signal in this shared worktree: unrelated untracked nested
repositories are present, and tracked `outputs/` scripts contain ten pre-existing
violations. The two changed files pass Ruff; no unrelated files were modified.

## Evidence scope

The changed production file is not in the five-claim registered-source inventory.
`alberta-evidence-status` still exits 2 from pre-existing registered-source drift; this
change does not silence or alter it. Historical hidden-partner and closed
slowly-changing-regression manifests that inventory this source remain untouched; their
stored identities do not describe this candidate. No pinned output, frozen seed, claim,
or reference configuration was modified or promoted.

## Immutable attachments

<!-- evidence-row:logs -->
- [x] logs: [verification log](https://github.com/user-attachments/assets/98a347e9-03de-4fee-ba6f-aeabd291ed5c)
  (payload SHA-256 `230a3d03a7ac68fd7a05f55d0ab1c23c7717306cd55eed7b3853bc00ff0903fa`,
  3,268 bytes)
<!-- evidence-row:domain-artifact -->
- [x] domain-artifact: [matched measurement artifact](https://github.com/user-attachments/assets/8a3ec3c5-bd38-4bbc-9d19-522a595f3612)
  (payload SHA-256 `6304d528b22ea037e4e7af34d4bad173ae49adf0de4898f4c876ff5ea4aee75d`,
  19,709 bytes)

GitHub CLI currently accepts only media at its immutable attachment endpoint, so each
linked SVG is a self-describing envelope whose `payload` metadata element contains the
exact named payload as base64. Decode that element and verify the stated byte count and
SHA-256; both envelopes were round-trip checked before upload and their authenticated
downloads matched the local envelope hashes.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi
Attribution status: self-reported
— [queue-review-20260911-next37]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"SlopDotCash/slopdotcash@1ace06c4b4a97d2c46830a19f4b77141e3d88c4c:skills/contribute-to-asi","run":{"schema_version":"2","run_id":"run_01M28A7V0B6DZRXTZYRTZ0F3SE","project":"asi","repository":"SlopDotCash/asi","started_at":"2026-09-11T13:24:17.036Z","completed_at":"2026-09-11T13:57:37.860Z","skill_sha256":"75d1f4b5fdc1969c88c0e40506f7bf4d4a2629eaaef18bd4bf4c50b0e2d6195b","policy_acknowledgement":{"policy_revision":"2026-08-20.1","license_sha256":"4c8d5abe876de66bf1cfbb2e9f2c486b41e53602d072628d2de4630957202a61","inbound_terms_sha256":"3302f9aa0da588c1c2f06e73af939af154466047346071b268e3b71bf6bb3443","prize_rules_sha256":null,"acknowledged_at":"2026-09-11T13:24:17.215Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"49cf23b678dd1fa0b4ce1a3e595c613eab76058dd22799e78f94690f7a4f5c55","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"98270c4a-33c1-4307-b66c-f3f0b6ebbda4","object_id":"sha256:49cf23b678dd1fa0b4ce1a3e595c613eab76058dd22799e78f94690f7a4f5c55","sha256":"49cf23b678dd1fa0b4ce1a3e595c613eab76058dd22799e78f94690f7a4f5c55"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAdeYe2lsD7XCy9Ng2afoRADAn-x1wgbIVrd3lQ6Mx9mA","device_key_id":"7a69a1f218f02160b524bb86d8dca61f50442aff185a4800daa2ceaece39f1fd","device_signature":"cx_jYtJ7vRZ8GK07pYB3gzReoxGF62_GwzWnQAn6Jp9KnHNpsAGJFVTPtzYSgG1uwIJb5nA7m2a-nXduG5qVAQ"}} -->
