### PR TITLE
fix(world-model): bind ensemble RNG to Threefry

### DIFF
--- a/alberta_framework/core/world_model_ensemble.py
+++ b/alberta_framework/core/world_model_ensemble.py
@@ -104,6 +104,27 @@ def _validated_config_float(name: str, value: object, **bounds: Any) -> float:
     return validated_float32_scalar(name, value, **bounds)
 
 
+def _require_typed_threefry_key(name: str, value: object) -> Array:
+    """Require one scalar typed Threefry key with exactly two uint32 words."""
+    dtype = getattr(value, "dtype", None)
+    if dtype is None or not jnp.issubdtype(dtype, jax.dtypes.prng_key):
+        raise TypeError(f"{name} must be a scalar typed Threefry JAX key")
+    trusted = cast(Array, value)
+    try:
+        implementation = str(jr.key_impl(trusted))
+        words = jr.key_data(trusted)
+    except (TypeError, ValueError) as error:
+        raise TypeError(f"{name} must be a scalar typed Threefry JAX key") from error
+    if (
+        trusted.shape != ()
+        or implementation != "threefry2x32"
+        or words.shape != (2,)
+        or words.dtype != jnp.uint32
+    ):
+        raise TypeError(f"{name} must be a scalar typed Threefry JAX key")
+    return trusted
+
+
 def _member_state_scalars(config: ActionConditionedWorldModelConfig) -> int:
     """Return exact default-LMS member state scalars counted by the budget surface."""
     input_dim = config.observation_dim + config.n_actions
@@ -936,6 +957,7 @@ class WorldModelEnsemble:
 
     def init(self, key: Array) -> WorldModelEnsembleState:
         """Initialize distinct members and isolated real/replay mask streams."""
+        key = _require_typed_threefry_key("key", key)
         keys = jr.split(key, self._config.ensemble_size + 1)
         member_states = tuple(
             self._model.init(keys[index]) for index in range(self._config.ensemble_size)
@@ -1135,12 +1157,10 @@ class WorldModelEnsemble:
             if array.shape != shape or array.dtype != jnp.dtype(dtype):
                 raise ValueError(f"{name} must have shape {shape} and dtype {dtype}")
 
-        key_data = jr.key_data(state.bootstrap_key)
-        if key_data.shape != (2,) or key_data.dtype != jnp.uint32:
-            raise ValueError("state.bootstrap_key must be one JAX PRNG key")
-        replay_key_data = jr.key_data(state.replay_bootstrap_key)
-        if replay_key_data.shape != (2,) or replay_key_data.dtype != jnp.uint32:
-            raise ValueError("state.replay_bootstrap_key must be one JAX PRNG key")
+        _require_typed_threefry_key("state.bootstrap_key", state.bootstrap_key)
+        _require_typed_threefry_key(
+            "state.replay_bootstrap_key", state.replay_bootstrap_key
+        )
 
     @staticmethod
     def _signal_state_valid(state: LearningSignalEstimatorState) -> Array:

--- a/tests/test_world_model_ensemble.py
+++ b/tests/test_world_model_ensemble.py
@@ -208,6 +208,45 @@ def test_init_uses_distinct_member_keys_and_isolated_real_replay_mask_keys() -> 
     )
 
 
+@pytest.mark.parametrize(
+    "key",
+    [
+        jr.PRNGKey(7),
+        jr.key(7, impl="rbg"),
+        jr.split(jr.key(7), 1),
+    ],
+)
+def test_init_rejects_keys_outside_scalar_typed_threefry_contract(key: jax.Array) -> None:
+    ensemble = WorldModelEnsemble(_config())
+    with pytest.raises(TypeError, match="scalar typed Threefry"):
+        ensemble.init(key)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["bootstrap_key", "replay_bootstrap_key"],
+)
+@pytest.mark.parametrize(
+    "key",
+    [
+        jr.PRNGKey(11),
+        jr.key(11, impl="rbg"),
+        jr.split(jr.key(11), 1),
+    ],
+)
+def test_static_state_contract_rejects_noncanonical_bootstrap_keys(
+    field: str,
+    key: jax.Array,
+) -> None:
+    ensemble = WorldModelEnsemble(_config())
+    state = ensemble.init(jr.key(11))
+    corrupt = state.replace(**{field: key})
+    with pytest.raises(TypeError, match=rf"state.{field} must be a scalar typed Threefry"):
+        ensemble.state_valid(corrupt)
+    with pytest.raises(TypeError, match=rf"state.{field} must be a scalar typed Threefry"):
+        ensemble.resource_budget(corrupt)
+
+
 def test_resource_budget_counts_member_lifetime_words_and_matches_state() -> None:
     ensemble = WorldModelEnsemble(_config())
     state = ensemble.init(jr.key(0))


### PR DESCRIPTION
`WorldModelEnsemble.init` accepted keys that produced states outside its own fixed-width RNG and resource contract. Typed RBG initialization on main returns a larger payload that `state_valid` and `resource_budget` reject. Raw legacy words can pass under Threefry but fail when the ambient implementation changes. Require scalar typed Threefry2x32 keys at initialization and adoption of both real/replay bootstrap streams.

The review repair preserves **ValueError for invalid adopted-state keys**, matching the existing state API; invalid initialization keys retain TypeError. The public init docstring explicitly declares the typed-only contract and shows `jr.wrap_key_data(..., impl="threefry2x32")` for callers with legacy words. Tests construct the rejected raw representation explicitly rather than assuming ambient `PRNGKey` layout. This is an intentional input-contract narrowing: word shape alone does not bind a legacy key’s implementation. [JAX’s PRNG documentation](https://docs.jax.dev/en/latest/jax.random.html) describes that distinction.

Validate the actual implementation through typed-key dtype equality against the existing explicitly created builtin Threefry template. A custom PRNG can reuse the builtin name or display tag, carry the same two words, and produce different random bits; both aliases passed the previous string check. Six failing-first regressions now reject those aliases at initialization and adoption of either bootstrap stream. This uses public typed-key properties and reuses the existing constructor template without adding an RNG draw or persisted numeric payload.

Pin all three module-owned template roots (member signature, default budget, checkpoint restoration) through one Threefry constant. Default budget and checkpoint restoration previously minted rejected RBG roots in an RBG-configured process. The new continuation test restores a checkpoint with its default template, performs actual real/replay learning, compares complete results and state to the original continuation, and checks canonical resource accounting. Caller-provided template keys pass through the same documented init contract.

Final head: `0c58fe67b0f23aa76be81b189011664673732abb`; original reviewed head: `a2f9f60fed74c5d19e43670bfbc2273ee28cefd7`; main baseline: `f3d32c451ed1c1715e477ad56b782fc7ea89b206`.

Verification:

- **All 56 hosted checks pass at the exact final head**, including `ci-ok`: [CI run](https://github.com/SlopDotCash/asi/actions/runs/35228975220).
- **55 ensemble tests pass** (185.33 s), including explicit JIT and persistence consumers.
- **136 adjacent tests pass** (45.63 s): ensemble validation, budgets, working sets and digest intake, Prototype integration, and rehearsal validation/budgets/working sets.
- **All 17 key-contract tests pass with ambient RBG** (42.92 s), including both owned-template gates and exact checkpoint continuation. No repository-wide RBG qualification is claimed.
- Synthetic composition with approved rehearsal-template PR #2935 (`ce05a9c17fe1b2a46e79f9f02db56929059e9acb`): all three consumer tests pass (21.25 s), including both action encodings through real rehearsal transactions. This composition is local and uncommitted; no dependency branch was changed.
- Full Ruff and strict mypy pass (224 source files); `git diff --check` passes.
- Failing first on the old head: **eight regressions fail** (23.63 s): six state exception cases and both RBG budget/restoration gates.
- Failing first on the intermediate repair: **six metadata-alias regressions fail** (15.33 s), with identical key words and implementation display strings but different random bits.
- Independent in-memory removal of the budget and checkpoint template pins makes the corresponding new gate fail at noncanonical initialization. Production files remain unchanged by these mutants.
- Main-method reproduction at public CI seed 17: canonical typed and legacy states each have 600-byte canonical numeric payloads and initially pass validation; typed RBG produces 616 bytes and fails the returned-state validator. The same legacy state then fails under an RBG default. The repair rejects legacy/RBG initialization and preserves complete canonical state identity with a fixed synthetic birth clock. This probe loads main’s unchanged constructor/init/static-validator methods in memory; it is not a separate authenticated full-module execution. Runtime: Python 3.12.3, JAX 0.11.0, NumPy 2.5.1, Linux CPU.

The five-claim evidence registry remains invalid (exit 2) from existing registered-source drift. All 25 registered source files are byte-identical to current main; this module is outside that inventory. No persisted identities, source hashes or validators were rewritten to silence drift.

Local qualification: `/tmp/asi-next76-verified-failing-first.log`, `/tmp/asi-next76-alias-failing-first.log`, `/tmp/asi-next76-final-{ensemble-tests,integration-panel,rbg-tests,mypy,budget-root-mutation,checkpoint-root-mutation,composed-full-tests}.log`, `/tmp/asi-next76-evidence-status.log`, `/tmp/asi-next76-final-baseline-probe.json`. Permanently nonpromoting synthetic key/state qualification; no benchmark campaign, dataset download, prospective seed reservation, reference configuration or pinned output was executed or changed. No performance, scientific, timing, authenticated-execution or robotics claim follows.

Original source-bound submission records remain historical at `a2f9f60f`, with their original fixture/runtime and TypeError-only development gate. That old gate is **not** asserted to pass unchanged on this repair: adopted-state errors intentionally return ValueError. Its original attachments remain referenced unchanged: [verification log](https://github.com/user-attachments/assets/6bc4e6c9-9cc9-4902-abf5-2372b367f84a) (declared payload SHA-256 `34bd32e54d52246f17e8ee0233e8e999214169acfce9d976a51de62225d7906d`, 3,860 bytes), [measurement artifact](https://github.com/user-attachments/assets/fee7d213-5d5b-47f1-b410-14df152290e0) (declared payload SHA-256 `221ef02ca184c6b733edbbed2da181dcbab10067217f3fb25f1baf80522b6401`, 28,560 bytes). These SVG envelopes contain base64 payload metadata and do not qualify the new head. The original PR body/receipt is retained locally at `/tmp/asi-next76-original-pr-body.md`; this repair has no new private trace or signed run receipt.

evidence-head: 0c58fe67b0f23aa76be81b189011664673732abb

AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: N/A - ordinary GitHub contribution without optional run evidence
Attribution status: self-reported
— [contributor]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"N/A - ordinary GitHub contribution without optional run evidence"} -->
