### PR TITLE
fix(behavior): stabilize temperature-scaled logits

### DIFF
--- a/alberta_framework/core/behavior_model.py
+++ b/alberta_framework/core/behavior_model.py
@@ -260,6 +260,19 @@ def action_log_likelihoods(
     )
 
 
+def _temperature_scaled_logits(logits: Array, temperature: float) -> Array:
+    """Scale logits without exposing a rounded argmax to softmax fusion."""
+    if temperature > 1.0:
+        # Halving both operands is exact and prevents centering opposite finite
+        # extremes from overflowing before a large temperature brings them in range.
+        logits = logits * 0.5
+        temperature *= 0.5
+    # Both shifts preserve softmax/log-softmax while keeping division in range.
+    centered = logits - jax.lax.stop_gradient(jnp.max(logits))
+    scaled = centered / temperature
+    return scaled - jax.lax.stop_gradient(jnp.max(scaled))
+
+
 def clipped_importance_ratios(
     target_probabilities: Array,
     behavior_probabilities: Array,
@@ -692,7 +705,7 @@ class BehaviorModel:
     ) -> Float[Array, " n_actions"]:
         """Predict behavior action probabilities for one feature vector."""
         logits = self.predict_logits(state, observation)
-        return jax.nn.softmax(logits / self._config.temperature)
+        return jax.nn.softmax(_temperature_scaled_logits(logits, self._config.temperature))
 
     def action_probability(
         self,
@@ -760,10 +773,10 @@ class BehaviorModel:
         cfg = self._config
         obs = jnp.asarray(observation, dtype=jnp.float32)
         logits = state.weights @ obs + state.bias
-        scaled_logits = logits / cfg.temperature
+        scaled_logits = _temperature_scaled_logits(logits, cfg.temperature)
         probabilities = jax.nn.softmax(scaled_logits)
         one_hot = jax.nn.one_hot(action_id, cfg.n_actions, dtype=jnp.float32)
-        loss = -jnp.sum(one_hot * jax.nn.log_softmax(scaled_logits))
+        loss = -jax.nn.log_softmax(scaled_logits)[action_id]
         logit_gradient = (probabilities - one_hot) / cfg.temperature
         gradient = state.weights.T @ logit_gradient
         gradient_norm = jnp.linalg.norm(gradient)
@@ -832,7 +845,8 @@ class BehaviorModel:
         cfg = self._config
         obs = jnp.asarray(observation, dtype=jnp.float32)
         logits = state.weights @ obs + state.bias
-        probabilities = jax.nn.softmax(logits / cfg.temperature)
+        scaled_logits = _temperature_scaled_logits(logits, cfg.temperature)
+        probabilities = jax.nn.softmax(scaled_logits)
         one_hot = jax.nn.one_hot(action_id, cfg.n_actions, dtype=jnp.float32)
 
         logit_error = (one_hot - probabilities) / cfg.temperature

--- a/tests/test_behavior_model.py
+++ b/tests/test_behavior_model.py
@@ -307,6 +307,76 @@ def test_temperature_rejects_subnormal_float32_before_softmax_division() -> None
     assert bool(jnp.isfinite(result.loss))
 
 
+def test_non_power_of_two_cooling_keeps_public_learned_policy_finite() -> None:
+    """A finite accepted update must not make the next cooled policy unusable."""
+    model = BehaviorModel(
+        BehaviorModelConfig(
+            n_actions=3,
+            step_size=0.05,
+            temperature=0.7,
+        )
+    )
+    observation = jnp.asarray([7.2e19], dtype=jnp.float32)
+    initial = model.init(feature_dim=1, key=jax.random.key(11))
+
+    first = model.update(initial, observation, jnp.asarray(0, dtype=jnp.int32))
+    assert bool(first.update_applied)
+    logits = model.predict_logits(first.state, observation)
+    assert bool(jnp.all(jnp.isfinite(logits)))
+    assert not bool(jnp.all(jnp.isfinite(logits / model.config.temperature)))
+
+    probabilities = model.predict_probabilities(first.state, observation)
+    chex.assert_tree_all_finite(probabilities)
+    chex.assert_trees_all_close(jnp.sum(probabilities), 1.0)
+    assert float(probabilities[0]) > 0.999
+
+    sampled = model.sample_action(first.state, observation)
+    chex.assert_tree_all_finite(
+        (
+            sampled.probabilities,
+            sampled.action_probability,
+            sampled.log_likelihood,
+        )
+    )
+    assert float(sampled.probabilities[0]) > 0.999
+
+    gradient = model.input_loss_gradient(
+        first.state,
+        observation,
+        jnp.asarray(0, dtype=jnp.int32),
+    )
+    assert bool(gradient.valid)
+    chex.assert_tree_all_finite(gradient)
+
+    continued = model.update(
+        first.state,
+        observation,
+        jnp.asarray(0, dtype=jnp.int32),
+    )
+    assert bool(continued.update_applied)
+    assert int(continued.state.step_count) == 2
+
+
+def test_large_temperature_preserves_finite_opposite_logit_separation() -> None:
+    """Pre-scaling centering must not overflow a finite heated distribution."""
+    model = BehaviorModel(BehaviorModelConfig(n_actions=2, temperature=1e38))
+    initial = model.init(feature_dim=1, key=jax.random.key(13))
+    state = initial.replace(
+        weights=jnp.asarray([[3e38], [-3e38]], dtype=jnp.float32),
+    )
+
+    logits = model.predict_logits(state, jnp.ones((1,), dtype=jnp.float32))
+    chex.assert_tree_all_finite(logits)
+    probabilities = model.predict_probabilities(state, jnp.ones((1,), dtype=jnp.float32))
+
+    chex.assert_tree_all_finite(probabilities)
+    np.testing.assert_allclose(
+        probabilities,
+        jax.nn.softmax(jnp.asarray([3.0, -3.0], dtype=jnp.float32)),
+        rtol=1e-5,
+    )
+
+
 def test_config_and_init_reject_boolean_or_nonpositive_dimensions() -> None:
     with pytest.raises(ValueError, match="n_actions"):
         BehaviorModelConfig(n_actions=True)
@@ -899,4 +969,3 @@ def test_floor_and_renormalize_probabilities_returns_simplex_on_zero_and_extreme
         out = floor_and_renormalize_probabilities(jnp.asarray(probs, dtype=jnp.float32))
         np.testing.assert_allclose(float(jnp.sum(out)), 1.0, atol=1e-5)
         assert np.all(np.asarray(out) >= 1e-6)
-


### PR DESCRIPTION
## Problem

`BehaviorModel` sends `logits / temperature` directly into compiled softmax and
log-softmax sites. With a non-power-of-two temperature, that evaluation order can
produce non-finite policy values from finite logits. On this x86 host, a public
`init -> update -> predict` path at `temperature=0.7` reproduces the failure once
the finite learned quotient overflows; issue #2886 additionally measures the
compiled contraction failure at much smaller finite magnitudes on arm64.

The same ordering also loses a finite heated distribution for opposite-sign
float32 logits and a large temperature.

## Change

- center logits before temperature scaling and center the scaled result again
- exactly halve numerator and denominator for temperatures above one, so
  centering opposite finite extremes cannot overflow before heating brings them
  back into range
- use indexed log-softmax loss instead of `one_hot * log_softmax`, avoiding
  `0 * -inf` contamination for a correctly saturated distribution
- cover prediction, sampling, input-gradient, and subsequent-update behavior
  through the public model API

This is a correctness-only `BehaviorModel` slice. It does not touch registered
evidence sources, run a benchmark, or make a performance/scientific claim.

Refs #2886.

## Validation

- failing first: the cooling regression failed on current main because
  `predict_probabilities` returned non-finite values
- `527 passed` across behavior-model, resource-budget, Step 9, dreaming, latent,
  and action-conditioned world-model tests
- `ruff check` passed for both changed files
- strict `mypy` passed for 224 source files
- `git diff --check` passed

AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: N/A - ordinary GitHub contribution without optional run evidence
Attribution status: self-reported
— [contributor]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"N/A - ordinary GitHub contribution without optional run evidence"} -->
