### PR TITLE
fix(rtu): stabilize temperature-scaled policies

### DIFF
--- a/alberta_framework/core/recurrent_trace_actor_critic.py
+++ b/alberta_framework/core/recurrent_trace_actor_critic.py
@@ -60,6 +60,19 @@ _MAXIMUM_THETA_LOG = math.log(2.0 * math.pi)
 _INT32_MAX = 2**31 - 1
 
 
+def _temperature_scaled_logits(logits: Array, temperature: float) -> Array:
+    """Scale logits without exposing a rounded argmax to softmax fusion."""
+    if temperature > 1.0:
+        # Halving both operands is exact and prevents centering opposite finite
+        # extremes from overflowing before a large temperature brings them in range.
+        logits = logits * 0.5
+        temperature *= 0.5
+    # Both shifts preserve softmax/log-softmax while keeping division in range.
+    centered = logits - jax.lax.stop_gradient(jnp.max(logits))
+    scaled = centered / temperature
+    return scaled - jax.lax.stop_gradient(jnp.max(scaled))
+
+
 def _validate_normal_float32_config_value(name: str, value: float) -> None:
     """Reject nonzero configuration values that are not normal float32 values.
 
@@ -2033,7 +2046,7 @@ class RecurrentTraceActorCriticAgent:
     ) -> Array:
         """Return the softmax policy of the already-advanced actor state."""
         logits = self._network_output(state.actor_params, state.actor_rtu_state)
-        return jax.nn.softmax(logits / self._config.temperature)
+        return jax.nn.softmax(_temperature_scaled_logits(logits, self._config.temperature))
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def value(
@@ -2053,7 +2066,7 @@ class RecurrentTraceActorCriticAgent:
     ) -> tuple[Array, Array, Array]:
         """Sample from the current recurrent policy without advancing it."""
         logits = self._network_output(state.actor_params, state.actor_rtu_state)
-        tempered_logits = logits / self._config.temperature
+        tempered_logits = _temperature_scaled_logits(logits, self._config.temperature)
         probabilities = jax.nn.softmax(tempered_logits)
         key, sample_key = jr.split(state.rng_key)
         action = jr.categorical(
@@ -2279,7 +2292,8 @@ class RecurrentTraceActorCriticAgent:
         entropy_sign = jax.lax.stop_gradient(jnp.sign(td_error))
 
         def policy_objective(logits: Array) -> Array:
-            log_probabilities = jax.nn.log_softmax(logits / self._config.temperature)
+            scaled_logits = _temperature_scaled_logits(logits, self._config.temperature)
+            log_probabilities = jax.nn.log_softmax(scaled_logits)
             probabilities = jnp.exp(log_probabilities)
             entropy = -jnp.sum(probabilities * log_probabilities)
             return (
@@ -2535,7 +2549,9 @@ class RecurrentTraceActorCriticAgent:
             state.actor_params,
             state.actor_rtu_state,
         )
-        current_log_policy = jax.nn.log_softmax(current_logits / self._config.temperature)
+        current_log_policy = jax.nn.log_softmax(
+            _temperature_scaled_logits(current_logits, self._config.temperature)
+        )
         current_policy = jnp.exp(current_log_policy)
         current_entropy = -jnp.sum(current_policy * current_log_policy)
 

--- a/tests/test_recurrent_trace_actor_critic.py
+++ b/tests/test_recurrent_trace_actor_critic.py
@@ -1208,6 +1208,69 @@ def test_action_sampling_uses_high_dynamic_range_tempered_logits(
     )
 
 
+def test_finite_policy_logits_remain_usable_at_minimum_temperature() -> None:
+    config = _small_config(
+        actor_alpha=0.0,
+        critic_alpha=0.0,
+        entropy_coefficient=0.0,
+        temperature=float(np.finfo(np.float32).tiny),
+    )
+    agent = RecurrentTraceActorCriticAgent(config)
+    state, _, _ = agent.start(
+        agent.init(feature_dim=2, key=jr.key(341)),
+        jnp.asarray((0.2, -0.4), dtype=jnp.float32),
+    )
+    logits = jnp.asarray((2.0, 4.0, 3.0), dtype=jnp.float32)
+    state = state.replace(
+        actor_params=state.actor_params._replace(
+            head_weights=jnp.zeros_like(state.actor_params.head_weights),
+            head_bias=logits,
+        ),
+        last_action=jnp.asarray(1, dtype=jnp.int32),
+    )
+    assert bool(jnp.all(jnp.isfinite(logits)))
+    assert not bool(jnp.all(jnp.isfinite(logits / config.temperature)))
+
+    policy = agent.policy(state)
+    action, next_key, sampled_policy = agent.select_action(state)
+    result = agent.update(
+        state.replace(rng_key=next_key),
+        jnp.asarray(0.25, dtype=jnp.float32),
+        jnp.asarray((-0.1, 0.3), dtype=jnp.float32),
+    )
+
+    expected = jnp.asarray((0.0, 1.0, 0.0), dtype=jnp.float32)
+    assert jnp.array_equal(policy, expected)
+    assert jnp.array_equal(sampled_policy, expected)
+    assert int(action) == 1
+    assert bool(result.update_applied)
+    assert bool(jnp.isfinite(result.entropy))
+    assert jnp.array_equal(result.policy, expected)
+    _assert_tree_finite(result)
+
+
+def test_large_temperature_preserves_finite_opposite_logit_separation() -> None:
+    config = _small_config(temperature=1e38)
+    agent = RecurrentTraceActorCriticAgent(config)
+    state = agent.init(feature_dim=2, key=jr.key(342))
+    logits = jnp.asarray((3e38, -3e38, 0.0), dtype=jnp.float32)
+    state = state.replace(
+        actor_params=state.actor_params._replace(
+            head_weights=jnp.zeros_like(state.actor_params.head_weights),
+            head_bias=logits,
+        )
+    )
+
+    probabilities = agent.policy(state)
+
+    _assert_tree_finite(probabilities)
+    np.testing.assert_allclose(
+        probabilities,
+        jax.nn.softmax(jnp.asarray((3.0, -3.0, 0.0), dtype=jnp.float32)),
+        rtol=1e-5,
+    )
+
+
 def test_entropy_diagnostic_uses_objective_log_softmax_path() -> None:
     config = _small_config(
         actor_alpha=0.0,


### PR DESCRIPTION
## Summary

- route recurrent policy, action sampling, actor gradients, and entropy diagnostics through one shift-invariant temperature-scaling helper
- center logits on both sides of the scale so XLA softmax/log-softmax fusion cannot re-form a rounded shared offset
- preserve heated distributions for opposite near-maximum finite logits by exactly halving both operands before centering

## Reproduction

On current main, the public minimum normal float32 temperature is accepted, but finite learned logits `[2, 4, 3]` overflow during direct scaling. `policy` returns `[nan, nan, nan]`, and the corresponding transition cannot remain a finite accepted recurrent update. The new unbatched regression failed first on that behavior and passes with the shared helper.

This is a bounded recurrent-trace slice of the broader backend report. It does not modify registered evidence sources, run benchmarks, or make a performance claim.

## Verification

- `138 passed in 93.71s` — recurrent actor-critic and update-working-set panels
- `2 passed in 6.16s` — minimum- and maximum-temperature regression pair
- `python -m ruff check .` — passed
- `python -m mypy` — passed across 224 source files
- synthetic merge with open PR #2870 — clean

Refs #2886

AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: N/A - ordinary GitHub contribution without optional run evidence
Attribution status: self-reported
— [contributor]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"N/A - ordinary GitHub contribution without optional run evidence"} -->
