### PR TITLE
fix(horde): stabilize temperature-scaled policies

### DIFF
--- a/alberta_framework/core/horde_actor_critic.py
+++ b/alberta_framework/core/horde_actor_critic.py
@@ -106,6 +106,19 @@ def _validated_actor_temperature(value: object) -> float:
     return temperature
 
 
+def _temperature_scaled_logits(logits: Array, temperature: float) -> Array:
+    """Scale logits without exposing a rounded argmax to softmax fusion."""
+    if temperature > 1.0:
+        # Halving both operands is exact and prevents centering opposite finite
+        # extremes from overflowing before a large temperature brings them in range.
+        logits = logits * 0.5
+        temperature *= 0.5
+    # Both shifts preserve softmax/log-softmax while keeping division in range.
+    centered = logits - jax.lax.stop_gradient(jnp.max(logits))
+    scaled = centered / temperature
+    return scaled - jax.lax.stop_gradient(jnp.max(scaled))
+
+
 def _exact_config_payload(config: object, expected: frozenset[str]) -> dict[str, Any]:
     if type(config) is not dict:
         raise ValueError("config must be an exact built-in dict")
@@ -625,7 +638,7 @@ class QHordeActorCriticAgent:
     ) -> Float[Array, " n_actions"]:
         """Compute softmax action probabilities for one observation."""
         logits = state.actor_weights @ observation + state.actor_bias
-        return jax.nn.softmax(logits / self._config.temperature)
+        return jax.nn.softmax(_temperature_scaled_logits(logits, self._config.temperature))
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def q_values(self, state: QHordeActorCriticState, observation: Array) -> Array:
@@ -921,7 +934,7 @@ class HordeActorCriticAgent:
     ) -> Float[Array, " n_actions"]:
         """Compute softmax action probabilities for one observation."""
         logits = state.actor_weights @ observation + state.actor_bias
-        return jax.nn.softmax(logits / self._config.temperature)
+        return jax.nn.softmax(_temperature_scaled_logits(logits, self._config.temperature))
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def values(self, state: HordeActorCriticState, observation: Array) -> Array:
@@ -1303,7 +1316,7 @@ def _nlhac_log_prob(
     )
     logits = head_w @ hidden + head_b
     # Keep the score in log space so finite extreme logits retain finite gradients.
-    log_probs = jax.nn.log_softmax(logits / temperature)
+    log_probs = jax.nn.log_softmax(_temperature_scaled_logits(logits, temperature))
     epsilon = jnp.asarray(actor_epsilon, dtype=log_probs.dtype)
     uniform_log_prob = jnp.log(epsilon) - jnp.log(
         jnp.asarray(log_probs.shape[0], dtype=log_probs.dtype)
@@ -1336,7 +1349,7 @@ def _nlqhac_expected_advantage_objective(
         trunk_weights, trunk_biases, obs, leaky_relu_slope, use_layer_norm
     )
     logits = head_w @ hidden + head_b
-    probs = jax.nn.softmax(logits / temperature)
+    probs = jax.nn.softmax(_temperature_scaled_logits(logits, temperature))
     return jnp.dot(probs, advantages)
 
 
@@ -1752,7 +1765,7 @@ class NonlinearHordeActorCriticAgent:
             cfg.use_layer_norm,
         )
         logits = state.actor_head_w @ hidden + state.actor_head_b
-        probs = jax.nn.softmax(logits / cfg.temperature)
+        probs = jax.nn.softmax(_temperature_scaled_logits(logits, cfg.temperature))
         return (1.0 - cfg.actor_epsilon) * probs + cfg.actor_epsilon / cfg.n_actions
 
     @functools.partial(jax.jit, static_argnums=(0,))
@@ -2461,7 +2474,7 @@ class NonlinearQHordeActorCriticAgent:
             cfg.use_layer_norm,
         )
         logits = state.actor_head_w @ hidden + state.actor_head_b
-        return jax.nn.softmax(logits / cfg.temperature)
+        return jax.nn.softmax(_temperature_scaled_logits(logits, cfg.temperature))
 
     @functools.partial(jax.jit, static_argnums=(0,))
     def q_values(self, state: NonlinearHordeActorCriticState, observation: Array) -> Array:

--- a/tests/test_horde_actor_critic_temperature_compatibility.py
+++ b/tests/test_horde_actor_critic_temperature_compatibility.py
@@ -1,0 +1,190 @@
+"""Temperature-scaling regressions shared by all Horde actor forms."""
+
+from collections.abc import Callable
+from typing import Any
+
+import chex
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from alberta_framework.core.horde import HordeLearner
+from alberta_framework.core.horde_actor_critic import (
+    HordeActorCriticAgent,
+    HordeActorCriticConfig,
+    NonlinearHordeActorCriticAgent,
+    NonlinearHordeActorCriticConfig,
+    NonlinearQHordeActorCriticAgent,
+    NonlinearQHordeActorCriticConfig,
+    QHordeActorCriticAgent,
+    QHordeActorCriticConfig,
+)
+from alberta_framework.core.types import DemonType, GVFSpec, create_horde_spec
+
+
+def _critic(*, control: bool) -> HordeLearner:
+    demons = [
+        GVFSpec(  # type: ignore[call-arg]
+            name=f"head_{index}",
+            demon_type=DemonType.CONTROL if control else DemonType.PREDICTION,
+            gamma=0.0,
+            lamda=0.0,
+            cumulant_index=-1,
+        )
+        for index in range(2 if control else 1)
+    ]
+    return HordeLearner(
+        create_horde_spec(demons),
+        hidden_sizes=(),
+        step_size=0.01,
+        use_layer_norm=False,
+    )
+
+
+def _linear_agents(temperature: float) -> tuple[Any, ...]:
+    return (
+        HordeActorCriticAgent(
+            HordeActorCriticConfig(
+                n_actions=2,
+                actor_step_size=0.05,
+                actor_lamda=0.7,
+                temperature=temperature,
+            ),
+            _critic(control=False),
+        ),
+        QHordeActorCriticAgent(
+            QHordeActorCriticConfig(
+                n_actions=2,
+                gamma=0.9,
+                actor_step_size=0.05,
+                actor_lamda=0.7,
+                temperature=temperature,
+            ),
+            _critic(control=True),
+        ),
+    )
+
+
+def _nonlinear_agents(temperature: float) -> tuple[Any, ...]:
+    return (
+        NonlinearHordeActorCriticAgent(
+            NonlinearHordeActorCriticConfig(
+                n_actions=2,
+                hidden_sizes=(),
+                actor_sparsity=0.0,
+                temperature=temperature,
+            ),
+            _critic(control=False),
+        ),
+        NonlinearQHordeActorCriticAgent(
+            NonlinearQHordeActorCriticConfig(
+                n_actions=2,
+                hidden_sizes=(),
+                actor_sparsity=0.0,
+                temperature=temperature,
+            ),
+            _critic(control=True),
+        ),
+    )
+
+
+@pytest.mark.parametrize("agent_index", [0, 1])
+def test_finite_linear_update_keeps_non_power_of_two_cooled_policy_finite(
+    agent_index: int,
+) -> None:
+    """An accepted finite update must not make the next public policy unusable."""
+    agent = _linear_agents(0.7)[agent_index]
+    observation = jnp.ones((1,), dtype=jnp.float32)
+    state = agent.init(feature_dim=1, key=jr.key(10 + agent_index)).replace(
+        last_observation=observation,
+        last_action=jnp.asarray(0, dtype=jnp.int32),
+    )
+
+    update_kwargs = (
+        {"terminated": jnp.asarray(False)} if isinstance(agent, QHordeActorCriticAgent) else {}
+    )
+    result = agent.update(
+        state,
+        reward=jnp.asarray(3e38, dtype=jnp.float32),
+        observation=observation,
+        **update_kwargs,
+    )
+    assert bool(result.update_applied)
+    chex.assert_tree_all_finite(result.state.replace(rng_key=jr.key_data(result.state.rng_key)))
+
+    next_observation = jnp.asarray([30.0], dtype=jnp.float32)
+    logits = result.state.actor_weights @ next_observation + result.state.actor_bias
+    chex.assert_tree_all_finite(logits)
+    probabilities = agent.policy(result.state, next_observation)
+
+    chex.assert_tree_all_finite(probabilities)
+    np.testing.assert_allclose(np.asarray(probabilities), np.asarray([1.0, 0.0]))
+    action, _next_key, sampled_probabilities = agent.select_action(result.state, next_observation)
+    assert int(action) == 0
+    chex.assert_tree_all_finite(sampled_probabilities)
+
+
+@pytest.mark.parametrize("agent_index", [0, 1])
+def test_nonlinear_policy_and_update_keep_finite_extreme_logits_usable(
+    agent_index: int,
+) -> None:
+    """The nonlinear policy and its differentiated update share stable scaling."""
+    agent = _nonlinear_agents(0.7)[agent_index]
+    observation = jnp.ones((1,), dtype=jnp.float32)
+    state = agent.init(feature_dim=1, key=jr.key(20 + agent_index)).replace(
+        actor_head_b=jnp.asarray([3e38, 2e38], dtype=jnp.float32),
+        last_observation=observation,
+        last_action=jnp.asarray(0, dtype=jnp.int32),
+    )
+
+    probabilities = agent.policy(state, observation)
+    chex.assert_tree_all_finite(probabilities)
+    np.testing.assert_allclose(np.asarray(probabilities), np.asarray([1.0, 0.0]))
+    action, _next_key, sampled_probabilities = agent.select_action(state, observation)
+    assert int(action) == 0
+    chex.assert_tree_all_finite(sampled_probabilities)
+
+    update_kwargs = (
+        {"terminated": jnp.asarray(0.0, dtype=jnp.float32)}
+        if isinstance(agent, NonlinearQHordeActorCriticAgent)
+        else {}
+    )
+    result = agent.update(
+        state,
+        reward=jnp.asarray(0.0, dtype=jnp.float32),
+        observation=observation,
+        **update_kwargs,
+    )
+    assert bool(result.update_applied)
+    chex.assert_tree_all_finite(result.policy)
+
+
+@pytest.mark.parametrize(
+    "agent_factory",
+    [
+        pytest.param(lambda temperature: _linear_agents(temperature)[0], id="linear"),
+        pytest.param(lambda temperature: _nonlinear_agents(temperature)[0], id="nonlinear"),
+    ],
+)
+def test_large_temperature_preserves_opposite_finite_logit_separation(
+    agent_factory: Callable[[float], Any],
+) -> None:
+    """Pre-scaling centering must not overflow a finite heated distribution."""
+    agent = agent_factory(1e38)
+    observation = jnp.ones((1,), dtype=jnp.float32)
+    state = agent.init(feature_dim=1, key=jax.random.key(30))
+    if isinstance(agent, HordeActorCriticAgent):
+        state = state.replace(actor_bias=jnp.asarray([3e38, -3e38], dtype=jnp.float32))
+    else:
+        state = state.replace(actor_head_b=jnp.asarray([3e38, -3e38], dtype=jnp.float32))
+
+    probabilities = agent.policy(state, observation)
+
+    chex.assert_tree_all_finite(probabilities)
+    np.testing.assert_allclose(
+        np.asarray(probabilities),
+        np.asarray(jax.nn.softmax(jnp.asarray([3.0, -3.0], dtype=jnp.float32))),
+        rtol=1e-5,
+    )


### PR DESCRIPTION
## Problem

All four Horde actor forms scale finite policy logits directly inside compiled
`softmax` or `log_softmax`. With non-power-of-two temperatures, finite learned logits can
therefore become a NaN policy; sampling consumes that policy, and the nonlinear gradient paths
reject an otherwise valid transaction.

On exact `main`, both linear agents accept a finite update driven by a finite `3e38` reward and
retain a fully finite state, but their next policy for a finite observation is `[nan, nan]`.
Both nonlinear public policies likewise return `[nan, nan]` for finite logits
`[3e38, 2e38]`, and their next differentiated update is rejected.

## Change

- add one shift-invariant temperature-scaling helper shared by both linear policies, both
  nonlinear policies, and both nonlinear policy-gradient objectives
- center on both sides of the scale so compiled softmax/log-softmax fusion cannot re-form a
  rounded shared offset
- exactly halve numerator and denominator above temperature one, preserving the finite heated
  distribution for opposite near-maximum float32 logits
- cover policy return values, categorical sampling, learned linear state, nonlinear transaction
  acceptance, and the large-temperature boundary across all four agent forms

This is the bounded `core/horde_actor_critic.py` slice of #2886. It does not touch a registered
evidence source, run a benchmark, or make a performance/scientific claim.

## Verification

- failing first on exact `main`: `6 failed` (all new regression nodes)
- fixed regression panel: `6 passed in 5.30s`
- retained Horde actor-critic plus regression panels: `103 passed in 84.35s`
- regression plus hostile-validation panels: `10 passed in 5.53s`
- Ruff on both changed files: passed
- strict mypy: passed across 224 source files
- `git diff --check origin/main...HEAD`: passed
- synthetic composition with open PRs #2867, #2868, and #2869: clean; combined six-file Horde
  panel `171 passed in 154.07s`, Ruff passed

Refs #2886

AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: N/A - ordinary GitHub contribution without optional run evidence
Attribution status: self-reported
— [contributor]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"N/A - ordinary GitHub contribution without optional run evidence"} -->
