### PR TITLE
fix(rule-discovery): stabilize NB vote scaling

### DIFF
--- a/alberta_framework/benchmarks/rule_discovery.py
+++ b/alberta_framework/benchmarks/rule_discovery.py
@@ -456,6 +456,14 @@ def _rms_mix(hidden: Array, f_rms: Array) -> Array:
     return f_rms * (hidden / rms) + (1.0 - f_rms) * hidden
 
 
+def _scaled_log_softmax(logits: Array, divisor: float) -> Array:
+    """Return a shift-invariant log-softmax after dividing finite logits."""
+    centered = logits - jax.lax.stop_gradient(jnp.max(logits))
+    scaled = centered / divisor
+    scaled = scaled - jax.lax.stop_gradient(jnp.max(scaled))
+    return jax.nn.log_softmax(scaled)
+
+
 def _loss_logits(
     params: dict[str, Array], x: Array, y: Array, f_rms: Array
 ) -> tuple[Array, tuple[Array, Array]]:
@@ -560,7 +568,7 @@ def rule_step(
     )
     s_net = jax.nn.log_softmax(logits)
     s_rls = jax.nn.log_softmax(_RLS_VOTE_TEMP * rls_scores)
-    s_nb = jax.nn.log_softmax(nb_ll / float(input_dim))
+    s_nb = _scaled_log_softmax(nb_ll, float(input_dim))
     w_net = state.member_acc[0]
     w_rls = f_rls * state.member_acc[1]
     w_nb = f_nb * state.member_acc[2]

--- a/tests/test_rule_discovery.py
+++ b/tests/test_rule_discovery.py
@@ -772,6 +772,47 @@ class TestExpandedMechanisms:
             assert moved[klass] == pytest.approx(0.0, abs=1e-8)
         assert float(new_state.nb_count[2]) == pytest.approx(1.0)
 
+    def test_nb_vote_preserves_finite_unbatched_accuracy_at_large_scale(self) -> None:
+        import jax
+
+        config = self._flagless_config()
+        config["nb_member"] = 1.0
+        genome = jnp.asarray(genome_from_config(config))
+        tiny = IPMNISTConfig(
+            n_tasks=1, task_length=1, input_dim=3, hidden1=2, hidden2=2, n_classes=3
+        )
+        params = jax.tree.map(jnp.zeros_like, init_mlp_params(jr.key(17), tiny))
+        params["b3"] = jnp.asarray([-3.0e37, 0.0, 6.1468536e36], jnp.float32)
+        state = init_rule_state(params)
+        mean_by_class = jnp.asarray([1.9730208e18, 1.8117479e18, 3.9466615e18])
+        state = dataclasses.replace(
+            state,
+            utility=jax.tree.map(jnp.ones_like, state.utility),
+            nb_mean=jnp.repeat(mean_by_class[:, None], tiny.input_dim, axis=1),
+            member_acc=jnp.asarray([1.0, 0.0, 1.0], jnp.float32),
+        )
+        reference_scores = (
+            np.asarray(params["b3"], dtype=np.float64)
+            - 0.5
+            * np.sum(np.asarray(state.nb_mean, dtype=np.float64) ** 2, axis=1)
+            / tiny.input_dim
+        )
+        assert int(np.argmax(reference_scores)) == 2
+
+        # Keep this row unbatched: vmap changes XLA's lowering and can mask
+        # the scaled-log-softmax contraction defect this regression exercises.
+        new_params, _, correct, loss = jax.jit(rule_step)(
+            genome,
+            params,
+            state,
+            jnp.zeros((tiny.input_dim,), jnp.float32),
+            jnp.asarray(2, jnp.int32),
+        )
+
+        assert float(correct) == 1.0
+        assert bool(jnp.isfinite(loss))
+        assert all(bool(jnp.all(jnp.isfinite(value))) for value in new_params.values())
+
     def test_lr_anneal_fast_when_surprised_slow_when_calm(self) -> None:
         config = self._flagless_config()
         config["lr_anneal"] = 1.0


### PR DESCRIPTION
## Summary

- center the naive-Bayes log scores before their non-power-of-two input-dimension scale
- center the scaled scores again before `log_softmax`, preventing XLA from reconstructing the unstable scaled subtraction
- pin the public, unbatched `rule_step` accuracy result against a finite high-precision score oracle

This is the remaining development-only `rule_discovery.py` site reported in #2886. It is a correctness fix only: no benchmark was run, no output artifact was touched, and it makes no performance, scientific, or evidence-promotion claim.

## Failing first

On exact `main` (`f3d32c451ed1c1715e477ad56b782fc7ea89b206`):

```text
tests/test_rule_discovery.py::TestExpandedMechanisms::test_nb_vote_preserves_finite_unbatched_accuracy_at_large_scale FAILED
E assert 0.0 == 1
```

The finite Gaussian and network scores select class 2 under the high-precision oracle; the compiled pre-fix path reported class 1. The regression is intentionally unbatched because `vmap` can change the XLA lowering and mask this defect.

## Verification

- `tests/test_rule_discovery.py`: 77 passed
- `tests/test_rule_discovery.py tests/test_rule_discovery_hostile_validation.py`: 94 passed
- strict mypy: 224 source files passed
- Ruff on both changed files: passed
- `git diff --check`: passed

AI provider/model: openai / gpt-5
Client / agent tooling: codex
Attribution status: self-reported
