### PR TITLE
fix(scorecard): durably publish JSON outputs

### DIFF
--- a/alberta_framework/benchmarks/reference_life_scorecard.py
+++ b/alberta_framework/benchmarks/reference_life_scorecard.py
@@ -1561,15 +1561,20 @@ def write_new_json(path: Path, value: Any) -> Path:
         view = memoryview(encoded)
         written = 0
         while written < len(view):
-            written += os.write(file_fd, view[written:])
+            count = os.write(file_fd, view[written:])
+            if count <= 0:
+                raise OSError("immutable output write made no progress")
+            written += count
         os.fsync(file_fd)
         os.fchmod(file_fd, 0o444)
+        os.fsync(file_fd)
         try:
             _link_unnamed_file(file_fd, parent_fd, destination.name)
         except FileExistsError as exc:
             raise FileExistsError(
                 f"refusing to overwrite immutable output: {destination}"
             ) from exc
+        os.fsync(parent_fd)
         return destination
     finally:
         if file_fd is not None:

--- a/tests/test_reference_life_scorecard.py
+++ b/tests/test_reference_life_scorecard.py
@@ -7,6 +7,7 @@ import dataclasses
 import json
 import math
 import os
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -418,6 +419,65 @@ def test_new_json_publication_is_canonical_and_refuses_overwrite(tmp_path: Path)
     ).encode("utf-8") + b"\n"
     with pytest.raises(FileExistsError, match="refusing to overwrite"):
         write_new_json(destination, {"different": math.pi})
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "O_TMPFILE"),
+    reason="write_new_json publishes through Linux O_TMPFILE and linkat(AT_EMPTY_PATH)",
+)
+def test_new_json_publication_rejects_a_zero_length_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "plan.json"
+    calls = 0
+
+    def zero_then_fail(file_fd: int, data: memoryview) -> int:
+        del file_fd, data
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return 0
+        raise RuntimeError("publisher retried after a zero-length write")
+
+    monkeypatch.setattr(scorecard.os, "write", zero_then_fail)
+    with pytest.raises(OSError, match="made no progress"):
+        write_new_json(destination, build_development_plan().to_payload())
+    assert not destination.exists()
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "O_TMPFILE"),
+    reason="write_new_json publishes through Linux O_TMPFILE and linkat(AT_EMPTY_PATH)",
+)
+def test_new_json_publication_durably_orders_mode_and_directory_sync(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "plan.json"
+    events: list[str] = []
+    real_fsync = os.fsync
+    real_fchmod = os.fchmod
+    real_link = scorecard._link_unnamed_file
+
+    def tracking_fsync(file_fd: int) -> None:
+        kind = "directory" if stat.S_ISDIR(os.fstat(file_fd).st_mode) else "file"
+        events.append(f"fsync_{kind}")
+        real_fsync(file_fd)
+
+    def tracking_fchmod(file_fd: int, mode: int) -> None:
+        events.append("fchmod")
+        real_fchmod(file_fd, mode)
+
+    def tracking_link(file_fd: int, parent_fd: int, name: str) -> None:
+        events.append("link")
+        real_link(file_fd, parent_fd, name)
+
+    monkeypatch.setattr(scorecard.os, "fsync", tracking_fsync)
+    monkeypatch.setattr(scorecard.os, "fchmod", tracking_fchmod)
+    monkeypatch.setattr(scorecard, "_link_unnamed_file", tracking_link)
+
+    write_new_json(destination, build_development_plan().to_payload())
+
+    assert events == ["fsync_file", "fchmod", "fsync_file", "link", "fsync_directory"]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Problem

The reference-life scorecard's create-only JSON publisher could spin indefinitely if
`os.write` made no progress. It also synced the file before changing it to read-only, but did
not sync that metadata change or the parent directory entry after publication. A process or
machine failure could therefore leave the scorecard output's final mode or linked name outside
the durability boundary even though publication returned successfully.

This is on the current 144-shard development scorecard output path. It does not affect or make a
performance/scientific claim, but it does affect whether its future plan, shard, and aggregate
records are safely retained.

## Change

- fail immediately if the immutable-output write loop makes no progress
- sync the prepared inode again after applying its read-only mode
- sync the descriptor-pinned parent after the create-only link
- pin the exact ordering and zero-write behavior with Linux publication tests

## Failing first

On exact `main` (`f3d32c451ed1c1715e477ad56b782fc7ea89b206`), both new tests failed:

```text
test_new_json_publication_rejects_a_zero_length_write FAILED
E RuntimeError: publisher retried after a zero-length write

test_new_json_publication_durably_orders_mode_and_directory_sync FAILED
E observed: ["fsync_file", "fchmod", "link"]
E expected: ["fsync_file", "fchmod", "fsync_file", "link", "fsync_directory"]
```

## Verification

- reference-life scorecard panel: `75 passed, 1 skipped`
- link fallback panel: `6 passed`
- strict mypy: `224 source files` passed
- Ruff on both changed files: passed
- `git diff --check`: passed

No scorecard shard, benchmark, seed, or output artifact was executed or written.

AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: N/A - ordinary GitHub contribution without optional run evidence
Attribution status: self-reported
— [contributor]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"N/A - ordinary GitHub contribution without optional run evidence"} -->
