### PR TITLE
fix(scorecard): preserve canonical receipt digests

### DIFF
--- a/.github/workflows/reference-life-scorecard-dev.yml
+++ b/.github/workflows/reference-life-scorecard-dev.yml
@@ -222,6 +222,8 @@ jobs:
                   "sha256": hashlib.sha256(raw).hexdigest(),
               }
 
+          plan_payload = json.loads((root / "plan.json").read_bytes())
+          artifact_payload = json.loads((root / "artifact.json").read_bytes())
           inventory = [record(path) for path in [root / "plan.json", root / "artifact.json", *shards]]
           canonical_inventory = json.dumps(
               inventory, sort_keys=True, separators=(",", ":"), ensure_ascii=True
@@ -257,8 +259,8 @@ jobs:
               "result": {
                   "file_count": len(inventory),
                   "shard_count": len(shards),
-                  "plan_sha256": inventory[0]["sha256"],
-                  "artifact_sha256": inventory[1]["sha256"],
+                  "plan_sha256": plan_payload["plan_sha256"],
+                  "artifact_sha256": artifact_payload["artifact_sha256"],
                   "campaign_inventory_sha256": hashlib.sha256(canonical_inventory).hexdigest(),
                   "inventory": inventory,
               },

--- a/tests/test_reference_life_scorecard_workflow.py
+++ b/tests/test_reference_life_scorecard_workflow.py
@@ -86,3 +86,14 @@ def test_reference_life_scorecard_artifacts_and_receipt_bind_the_run() -> None:
         assert field in text
     assert "path: scorecard\n" not in text
     assert "scorecard/run-receipt.v1.json" in text
+
+
+def test_reference_life_scorecard_receipt_preserves_canonical_digests() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'plan_payload = json.loads((root / "plan.json").read_bytes())' in text
+    assert 'artifact_payload = json.loads((root / "artifact.json").read_bytes())' in text
+    assert '"plan_sha256": plan_payload["plan_sha256"]' in text
+    assert '"artifact_sha256": artifact_payload["artifact_sha256"]' in text
+    assert '"plan_sha256": inventory[0]["sha256"]' not in text
+    assert '"artifact_sha256": inventory[1]["sha256"]' not in text


### PR DESCRIPTION
## Summary

- preserve the scorecard plan's embedded canonical `plan_sha256` in the GitHub run receipt
- preserve the validated aggregate's embedded canonical `artifact_sha256` in the receipt
- keep transport-byte hashes for both files in the existing campaign inventory
- add a regression test that rejects the previous inventory-index substitutions

## Why

The receipt fields named `plan_sha256` and `artifact_sha256` were populated from the SHA-256 hashes of the pretty-printed JSON files. Those differ from the canonical schema digests embedded in the validated plan and aggregate artifact, so a downstream consumer could not use the receipt fields to bind the schema identities they name.

## Validation

- Failure-first: the new workflow regression test failed against the previous implementation.
- `.venv/bin/python -m pytest tests/test_reference_life_scorecard.py tests/test_reference_life_scorecard_workflow.py -q -o addopts=`: 73 passed, 1 skipped
- `.venv/bin/python -m ruff check tests/test_reference_life_scorecard_workflow.py`: passed
- `.venv/bin/python -m mypy`: passed
- `git diff --check`: passed

No scorecard campaign was dispatched, and no seed, benchmark result, or output artifact was created or changed. This is workflow/receipt correctness for the permanently nonpromoting development scorecard only.

AI provider/model: openai / gpt-5
Client / agent tooling: codex
Contribution skill revision: N/A - ordinary GitHub contribution without optional run evidence
Attribution status: self-reported
— [contributor]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex","skill_revision":"N/A - ordinary GitHub contribution without optional run evidence"} -->
